### PR TITLE
fix getCurrentTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.6.0
+* @akashic/akashic-engineのminor更新に伴うバージョンアップ
+
 ## 1.5.0
 * @akashic/amflowのminor更新に伴うバージョンアップ
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@akashic:registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
-    "@akashic/akashic-pdi": "~2.5.0",
+    "@akashic/akashic-pdi": "~2.6.0",
     "@akashic/amflow": "~0.3.1",
     "@akashic/playlog": "~1.3.2",
     "@types/jasmine-node": "1.14.33",
@@ -61,7 +61,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
-    "@akashic/akashic-engine": "~2.5.0",
+    "@akashic/akashic-engine": "^2.5.1",
     "es6-promise": "^3.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",
@@ -61,7 +61,7 @@
     "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
-    "@akashic/akashic-engine": "~2.4.2",
+    "@akashic/akashic-engine": "~2.5.0",
     "es6-promise": "^3.1.2"
   }
 }

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -166,7 +166,8 @@ export class Game extends g.Game {
 	}
 
 	getCurrentTime(): number {
-		return this._getCurrentTimeFunc();
+		// GameLoopの同名メソッドとは戻り値が異なるが、 `Game.getCurrentTime()` は `Date.now()` の代替として使用されるため、整数値を返す。
+		return this._getCurrentTimeFunc() | 0;
 	}
 
 	raiseEvent(event: g.Event): void {


### PR DESCRIPTION
## このpull requestが解決する内容

https://github.com/akashic-games/akashic-engine/pull/124 の実装修正です。
<!-- Pull Requestの変更内容の概要を書いてください -->
`g.game.getCurrentTime()` の戻り値が整数になるよう変更します。
これは、上記メソッドを `Date.now()` の代わりにakashicコンテンツ内で使うため、互換性を取るための措置です。

## 破壊的な変更を含んでいるか?

- あり

従来小数で返されていた値が、今後は整数で返るようになります。
