### PR TITLE
MemoryAmflowClientのプレイログ情報をcloneして保持するようにする修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.6.5
+* `MemoryAmflowClient#sendTick` と `MemoryAmflowClient#sendEvent` で取得するプレイログ情報を clone して保持するように修正
+
 ## 1.6.4
 * `g.Game#random#generate()` を追加
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 1.6.5
-* `MemoryAmflowClient#sendTick` と `MemoryAmflowClient#sendEvent` で取得するプレイログ情報を clone して保持するように修正
+* `MemoryAmflowClient#sendTick` と `MemoryAmflowClient#sendEvent` で送信するプレイログ情報を clone して保持するように修正
 
 ## 1.6.4
 * `g.Game#random#generate()` を追加

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",
@@ -40,6 +40,7 @@
     "@akashic/amflow": "~0.3.1",
     "@akashic/playlog": "~1.3.2",
     "@types/jasmine-node": "1.14.33",
+    "@types/lodash.clonedeep": "4.5.6",
     "@types/node": "10.11.6",
     "browserify": "^13.0.0",
     "gulp": "^3.8.11",
@@ -62,6 +63,7 @@
   },
   "dependencies": {
     "@akashic/akashic-engine": "~2.5.2",
-    "es6-promise": "^3.1.2"
+    "es6-promise": "^3.1.2",
+    "lodash.clonedeep": "~4.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   },
   "dependencies": {
     "@akashic/akashic-engine": "~2.5.2",
-    "es6-promise": "^3.1.2",
-    "lodash.clonedeep": "~4.5.0"
+    "es6-promise": "^3.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "@akashic/amflow": "~0.3.1",
     "@akashic/playlog": "~1.3.2",
     "@types/jasmine-node": "1.14.33",
-    "@types/lodash.clonedeep": "4.5.6",
     "@types/node": "10.11.6",
     "browserify": "^13.0.0",
     "gulp": "^3.8.11",

--- a/spec/src/auxiliary/MemoryAmflowClientSpec.ts
+++ b/spec/src/auxiliary/MemoryAmflowClientSpec.ts
@@ -93,6 +93,20 @@ describe("MemoryAmflowClient", function () {
 				done.fail();
 			});
 		});
+
+		it("can save clone of sent tick", function () {
+			const self = new MemoryAmflowClient({
+				playId: "testuser"
+			});
+			const age = 5;
+			const targetTick: pl.Tick = [age, [joinEvent]];
+			self.sendTick(targetTick);
+			expect(self._tickList).toEqual([age, age, [[age, [joinEvent]]]]);
+
+			// sendしたtickの値を変更しても_tickListの中身が変わらないことを確認
+			targetTick[0] = 3;
+			expect(self._tickList).toEqual([age, age, [[age, [joinEvent]]]]);
+		});
 	});
 
 	describe("#dropAfter", function () {
@@ -304,6 +318,20 @@ describe("MemoryAmflowClient", function () {
 				expect(startPoint).toEqual(sp18);
 				done();
 			});
+		});
+	});
+	describe("#sendEvent", function() {
+		it("can save clone of sent event", function () {
+			const self = new MemoryAmflowClient({
+				playId: "testuser"
+			});
+			const joinEvent: pl.JoinEvent = [ pl.EventCode.Join, EventPriority.System, "dummyPlayerId", "dummy-name", null];
+			self.sendEvent(joinEvent);
+			expect(self._events).toEqual([[ pl.EventCode.Join, EventPriority.System, "dummyPlayerId", "dummy-name", null]]);
+
+			// sendしたeventの値を変更しても_eventsの中身が変わらないことを確認
+			joinEvent[3] = "0000";
+			expect(self._events).toEqual([[ pl.EventCode.Join, EventPriority.System, "dummyPlayerId", "dummy-name", null]]);
 		});
 	});
 });

--- a/spec/src/auxiliary/MemoryAmflowClientSpec.ts
+++ b/spec/src/auxiliary/MemoryAmflowClientSpec.ts
@@ -1,9 +1,7 @@
 import * as pl from "@akashic/playlog";
 import * as amf from "@akashic/amflow";
-import * as pdi from "@akashic/akashic-pdi";
-import * as EventIndex from "../../../lib/EventIndex";
 import EventPriority from "../../../lib/EventPriority";
-import { MemoryAmflowClient } from "../../../lib/auxiliary/MemoryAmflowClient";
+import { MemoryAmflowClient, _cloneDeep } from "../../../lib/auxiliary/MemoryAmflowClient";
 
 describe("MemoryAmflowClient", function () {
 
@@ -94,7 +92,7 @@ describe("MemoryAmflowClient", function () {
 			});
 		});
 
-		it("can save clone of sent tick", function () {
+		it("clones given ticks", function () {
 			const self = new MemoryAmflowClient({
 				playId: "testuser"
 			});
@@ -322,7 +320,7 @@ describe("MemoryAmflowClient", function () {
 	});
 
 	describe("#sendEvent", function() {
-		it("can save clone of sent event", function () {
+		it("clones given events", function () {
 			const self = new MemoryAmflowClient({
 				playId: "testuser"
 			});
@@ -337,19 +335,16 @@ describe("MemoryAmflowClient", function () {
 	});
 
 	describe("#_cloneDeep", function() {
-		const self = new MemoryAmflowClient({
-			playId: "testuser"
-		});
 		it("can copy primitive-value", function () {
-			expect(self._cloneDeep(1)).toBe(1);
-			expect(self._cloneDeep("hoge")).toBe("hoge");
-			expect(self._cloneDeep(true)).toBe(true);
-			expect(self._cloneDeep(null)).toBe(null);
-			expect(self._cloneDeep(undefined)).toBe(undefined);
+			expect(_cloneDeep(1)).toBe(1);
+			expect(_cloneDeep("hoge")).toBe("hoge");
+			expect(_cloneDeep(true)).toBe(true);
+			expect(_cloneDeep(null)).toBe(null);
+			expect(_cloneDeep(undefined)).toBe(undefined);
 		});
 		it("can copy json-data", function () {
 			const array = [1 , "hoge", true, null, undefined, [2, "fuga", false, null, undefined]];
-			const arrayClone = self._cloneDeep(array);
+			const arrayClone = _cloneDeep(array);
 			expect(arrayClone).toEqual(array);
 			expect(arrayClone).not.toBe(array);
 
@@ -366,18 +361,18 @@ describe("MemoryAmflowClient", function () {
 					}
 				}
 			};
-			const jsonClone = self._cloneDeep(json);
+			const jsonClone = _cloneDeep(json);
 			expect(jsonClone).toEqual(json);
 			expect(jsonClone).not.toBe(json);
 		});
 		it("can copy event and tick", function () {
 			const joinEvent: pl.JoinEvent = [pl.EventCode.Join, EventPriority.System, "dummyPlayerId", "dummy-name", null];
-			const joinEventClone = self._cloneDeep(joinEvent);
+			const joinEventClone = _cloneDeep(joinEvent);
 			expect(joinEventClone).toEqual(joinEvent);
 			expect(joinEventClone).not.toBe(joinEvent);
 
 			const joinEventTick: pl.Tick = [0, [joinEvent]];
-			const joinEventTickClone = self._cloneDeep(joinEventTick);
+			const joinEventTickClone = _cloneDeep(joinEventTick);
 			expect(joinEventTickClone).toEqual(joinEventTick);
 			expect(joinEventTickClone).not.toBe(joinEventTick);
 		});

--- a/spec/src/auxiliary/MemoryAmflowClientSpec.ts
+++ b/spec/src/auxiliary/MemoryAmflowClientSpec.ts
@@ -320,6 +320,7 @@ describe("MemoryAmflowClient", function () {
 			});
 		});
 	});
+
 	describe("#sendEvent", function() {
 		it("can save clone of sent event", function () {
 			const self = new MemoryAmflowClient({
@@ -332,6 +333,53 @@ describe("MemoryAmflowClient", function () {
 			// sendしたeventの値を変更しても_eventsの中身が変わらないことを確認
 			joinEvent[3] = "0000";
 			expect(self._events).toEqual([[ pl.EventCode.Join, EventPriority.System, "dummyPlayerId", "dummy-name", null]]);
+		});
+	});
+
+	describe("#_cloneDeep", function() {
+		const self = new MemoryAmflowClient({
+			playId: "testuser"
+		});
+		it("can copy primitive-value", function () {
+			expect(self._cloneDeep(1)).toBe(1);
+			expect(self._cloneDeep("hoge")).toBe("hoge");
+			expect(self._cloneDeep(true)).toBe(true);
+			expect(self._cloneDeep(null)).toBe(null);
+			expect(self._cloneDeep(undefined)).toBe(undefined);
+		});
+		it("can copy json-data", function () {
+			const array = [1 , "hoge", true, null, undefined, [2, "fuga", false, null, undefined]];
+			const arrayClone = self._cloneDeep(array);
+			expect(arrayClone).toEqual(array);
+			expect(arrayClone).not.toBe(array);
+
+			const json = {
+				"key1": "value",
+				2 : 2,
+				"key3": true,
+				"key4": [2, "fuga", false, null, {"sub1": "aa", "sub2": true}],
+				"key5": {
+					"key5-1": "value",
+					"key5-2": {
+						1: "fugafuga",
+						"key5-2-2": [2, "value5-2", undefined]
+					}
+				}
+			};
+			const jsonClone = self._cloneDeep(json);
+			expect(jsonClone).toEqual(json);
+			expect(jsonClone).not.toBe(json);
+		});
+		it("can copy event and tick", function () {
+			const joinEvent: pl.JoinEvent = [pl.EventCode.Join, EventPriority.System, "dummyPlayerId", "dummy-name", null];
+			const joinEventClone = self._cloneDeep(joinEvent);
+			expect(joinEventClone).toEqual(joinEvent);
+			expect(joinEventClone).not.toBe(joinEvent);
+
+			const joinEventTick: pl.Tick = [0, [joinEvent]];
+			const joinEventTickClone = self._cloneDeep(joinEventTick);
+			expect(joinEventTickClone).toEqual(joinEventTick);
+			expect(joinEventTickClone).not.toBe(joinEventTick);
 		});
 	});
 });

--- a/spec/src/auxiliary/MemoryAmflowClientSpec.ts
+++ b/spec/src/auxiliary/MemoryAmflowClientSpec.ts
@@ -74,7 +74,7 @@ describe("MemoryAmflowClient", function () {
 				});
 			});
 		});
-		
+
 		it("push same tick to tickList", function (done: any) {
 			var self = new MemoryAmflowClient({
 				playId: "testuser",

--- a/src/auxiliary/MemoryAmflowClient.ts
+++ b/src/auxiliary/MemoryAmflowClient.ts
@@ -1,5 +1,4 @@
 "use strict";
-import cloneDeep = require("lodash.clonedeep");
 import * as amf from "@akashic/amflow";
 import * as pl from "@akashic/playlog";
 import * as EventIndex from "../EventIndex";
@@ -124,7 +123,7 @@ export class MemoryAmflowClient implements amf.AMFlow {
 	}
 
 	sendTick(tick: pl.Tick): void {
-		tick = this.cloneDeep<pl.Tick>(tick);
+		tick = this._cloneDeep(tick);
 
 		if (!this._tickList) {
 			this._tickList = [tick[EventIndex.Tick.Age], tick[EventIndex.Tick.Age], []];
@@ -154,7 +153,7 @@ export class MemoryAmflowClient implements amf.AMFlow {
 	}
 
 	sendEvent(pev: pl.Event): void {
-		pev = this.cloneDeep<pl.Event>(pev);
+		pev = this._cloneDeep(pev);
 
 		if (this._eventHandlers.length === 0) {
 			this._events.push(pev);
@@ -269,7 +268,16 @@ export class MemoryAmflowClient implements amf.AMFlow {
 		}
 	}
 
-	private cloneDeep<T>(target: T): T {
-		return cloneDeep(target);
+	_cloneDeep(v: any): any {
+		if (typeof v === "number" || typeof v === "string" || typeof v === "boolean" || v === null) {
+			return v;
+		} else if (v && typeof v === "object") {
+			if (v instanceof Array) {
+				return v.map(this._cloneDeep.bind(this));
+			} else {
+				return Object.keys(v).reduce((acc: any, k) => (acc[k] = this._cloneDeep(v[k]), acc), {});
+			}
+		}
+		return v;
 	}
 }

--- a/src/auxiliary/MemoryAmflowClient.ts
+++ b/src/auxiliary/MemoryAmflowClient.ts
@@ -123,7 +123,7 @@ export class MemoryAmflowClient implements amf.AMFlow {
 	}
 
 	sendTick(tick: pl.Tick): void {
-		tick = _cloneDeep(tick);
+		tick = _cloneDeep(tick); // _cloneDeepで値をコピーしているだけで元の値の破壊的変更は行っていない
 
 		if (!this._tickList) {
 			this._tickList = [tick[EventIndex.Tick.Age], tick[EventIndex.Tick.Age], []];
@@ -153,7 +153,7 @@ export class MemoryAmflowClient implements amf.AMFlow {
 	}
 
 	sendEvent(pev: pl.Event): void {
-		pev = _cloneDeep(pev);
+		pev = _cloneDeep(pev); // _cloneDeepで値をコピーしているだけで元の値の破壊的変更は行っていない
 
 		if (this._eventHandlers.length === 0) {
 			this._events.push(pev);

--- a/src/auxiliary/MemoryAmflowClient.ts
+++ b/src/auxiliary/MemoryAmflowClient.ts
@@ -123,7 +123,7 @@ export class MemoryAmflowClient implements amf.AMFlow {
 	}
 
 	sendTick(tick: pl.Tick): void {
-		tick = _cloneDeep(tick); // _cloneDeepで値をコピーしているだけで元の値の破壊的変更は行っていない
+		tick = _cloneDeep(tick); // 元の値が後から変更されてもいいようにコピーしておく
 
 		if (!this._tickList) {
 			this._tickList = [tick[EventIndex.Tick.Age], tick[EventIndex.Tick.Age], []];
@@ -153,7 +153,7 @@ export class MemoryAmflowClient implements amf.AMFlow {
 	}
 
 	sendEvent(pev: pl.Event): void {
-		pev = _cloneDeep(pev); // _cloneDeepで値をコピーしているだけで元の値の破壊的変更は行っていない
+		pev = _cloneDeep(pev); // 元の値が後から変更されてもいいようにコピーしておく
 
 		if (this._eventHandlers.length === 0) {
 			this._events.push(pev);

--- a/src/auxiliary/MemoryAmflowClient.ts
+++ b/src/auxiliary/MemoryAmflowClient.ts
@@ -124,25 +124,25 @@ export class MemoryAmflowClient implements amf.AMFlow {
 	}
 
 	sendTick(tick: pl.Tick): void {
-		const tickClone = this.cloneDeep<pl.Tick>(tick);
+		tick = this.cloneDeep<pl.Tick>(tick);
 
 		if (!this._tickList) {
-			this._tickList = [tickClone[EventIndex.Tick.Age], tickClone[EventIndex.Tick.Age], []];
+			this._tickList = [tick[EventIndex.Tick.Age], tick[EventIndex.Tick.Age], []];
 		} else {
 			// 既に存在するTickListのfrom~to間にtickが挿入されることは無い
-			if (this._tickList[EventIndex.TickList.From] <= tickClone[EventIndex.Tick.Age] &&
-				tickClone[EventIndex.Tick.Age] <= this._tickList[EventIndex.TickList.To]
+			if (this._tickList[EventIndex.TickList.From] <= tick[EventIndex.Tick.Age] &&
+				tick[EventIndex.Tick.Age] <= this._tickList[EventIndex.TickList.To]
 			)
 				throw new Error("illegal age tick");
 
-			this._tickList[EventIndex.TickList.To] = tickClone[EventIndex.Tick.Age];
+			this._tickList[EventIndex.TickList.To] = tick[EventIndex.Tick.Age];
 		}
 
-		if (!!tickClone[EventIndex.Tick.Events] || !!tickClone[EventIndex.Tick.StorageData]) {
-			this._tickList[EventIndex.TickList.TicksWithEvents].push(tickClone);
+		if (!!tick[EventIndex.Tick.Events] || !!tick[EventIndex.Tick.StorageData]) {
+			this._tickList[EventIndex.TickList.TicksWithEvents].push(tick);
 		}
 
-		this._tickHandlers.forEach((h: (t: pl.Tick) => void) => h(tickClone));
+		this._tickHandlers.forEach((h: (t: pl.Tick) => void) => h(tick));
 	}
 
 	onTick(handler: (tick: pl.Tick) => void): void {
@@ -154,13 +154,13 @@ export class MemoryAmflowClient implements amf.AMFlow {
 	}
 
 	sendEvent(pev: pl.Event): void {
-		const eventClone = this.cloneDeep<pl.Event>(pev);
+		pev = this.cloneDeep<pl.Event>(pev);
 
 		if (this._eventHandlers.length === 0) {
-			this._events.push(eventClone);
+			this._events.push(pev);
 			return;
 		}
-		this._eventHandlers.forEach((h: (pev: pl.Event) => void) => h(eventClone));
+		this._eventHandlers.forEach((h: (pev: pl.Event) => void) => h(pev));
 	}
 
 	onEvent(handler: (pev: pl.Event) => void): void {

--- a/src/auxiliary/MemoryAmflowClient.ts
+++ b/src/auxiliary/MemoryAmflowClient.ts
@@ -123,7 +123,7 @@ export class MemoryAmflowClient implements amf.AMFlow {
 	}
 
 	sendTick(tick: pl.Tick): void {
-		tick = this._cloneDeep(tick);
+		tick = _cloneDeep(tick);
 
 		if (!this._tickList) {
 			this._tickList = [tick[EventIndex.Tick.Age], tick[EventIndex.Tick.Age], []];
@@ -153,7 +153,7 @@ export class MemoryAmflowClient implements amf.AMFlow {
 	}
 
 	sendEvent(pev: pl.Event): void {
-		pev = this._cloneDeep(pev);
+		pev = _cloneDeep(pev);
 
 		if (this._eventHandlers.length === 0) {
 			this._events.push(pev);
@@ -267,17 +267,15 @@ export class MemoryAmflowClient implements amf.AMFlow {
 			this._startPoints = this._startPoints.filter((sp) => sp.frame < age);
 		}
 	}
+}
 
-	_cloneDeep(v: any): any {
-		if (typeof v === "number" || typeof v === "string" || typeof v === "boolean" || v === null) {
-			return v;
-		} else if (v && typeof v === "object") {
-			if (v instanceof Array) {
-				return v.map(this._cloneDeep.bind(this));
-			} else {
-				return Object.keys(v).reduce((acc: any, k) => (acc[k] = this._cloneDeep(v[k]), acc), {});
-			}
+export function _cloneDeep(v: any): any {
+	if (v && typeof v === "object") {
+		if (Array.isArray(v)) {
+			return v.map(_cloneDeep);
+		} else {
+			return Object.keys(v).reduce((acc: any, k) => (acc[k] = _cloneDeep(v[k]), acc), {});
 		}
-		return v;
 	}
+	return v;
 }


### PR DESCRIPTION
### 概要
* 送信したプレイログ情報と保持しているプレイログ情報が同じものになっていることで問題が発生することがあったので、MemoryAmflowClient のプレイログ情報保存時にデータを deep cloneするように修正しました。

### やったこと
* `MemoryAmflowClient#sendTick` と `MemoryAmflowClient#sendEvent`で取得したデータをlodash.clonedeepを用いてdeep clone