### PR TITLE
Make skip when game looper has been stopped above SKIP_THRESHOLD

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/spec/src/GameLoopSpec.ts
+++ b/spec/src/GameLoopSpec.ts
@@ -251,6 +251,93 @@ describe("GameLoop", function () {
 		});
 	});
 
+	it("can detect skip based on deltaTime of the looper arguments", async () => {
+		const amflow = new MemoryAmflowClient({
+			playId: "dummyPlayId",
+			tickList: [0, 9, []],
+			startPoints: [{
+				frame: 0,
+				timestamp: 0,
+				data: {
+					seed: 42,
+					startedAt: 10000
+				}
+			}]
+		});
+		const platform = new mockpf.Platform({});
+		const game = prepareGame({ title: FixtureGame.LocalTickGame, playerId: "dummyPlayerId" });
+		const eventBuffer = new EventBuffer({ amflow, game });
+		const self = new GameLoop({
+			amflow,
+			platform,
+			game,
+			eventBuffer,
+			executionMode: ExecutionMode.Passive,
+			configuration: {
+				jumpTryThreshold: 2,
+				loopMode: LoopMode.Realtime
+			},
+			startedAt: 140
+		});
+		self.start();
+
+		amflow.sendTick([10]); // Realtimeで非Manualなのでtickをpushされないと何も動かない
+
+		const looper = self._clock._looper as mockpf.Looper;
+		game._reset({ age: 0, randGen: new g.XorshiftRandomGenerator(0) });
+		game._loadAndStart({ args: undefined });
+
+		// 最新の状態まで追いつく
+		await new Promise((resolve, reject) => {
+			const timer = setInterval(() => {
+				if (game.age > 10) {
+					clearInterval(timer);
+					resolve();
+					return;
+				}
+				looper.fun(self._frameTime);
+			}, 1);
+		});
+
+		amflow.sendTick([20]); // 新しいtickを送信
+
+		// 最新の状態まで追いつく
+		await new Promise((resolve, reject) => {
+			let skipCalled = false;
+			game.skippingChangedTrigger.add(() => {
+				skipCalled = true;
+			});
+			const timer = setInterval(() => {
+				if (game.age > 20) {
+					expect(skipCalled).toBe(true); // skippingChangedTrigger が呼ばれていることを確認
+					clearInterval(timer);
+					resolve();
+					return;
+				}
+				looper.fun(self._skipThresholdTime + 1);
+			}, 1);
+		});
+
+		amflow.sendTick([30]); // 新しいtickを送信
+
+		// 最新の状態まで追いつく
+		await new Promise((resolve, reject) => {
+			let skipCalled = false;
+			game.skippingChangedTrigger.add(() => {
+				skipCalled = true;
+			});
+			const timer = setInterval(() => {
+				if (game.age > 30) {
+					expect(skipCalled).toBe(false); // skippingChangedTrigger が呼ばれていないことを確認
+					clearInterval(timer);
+					resolve();
+					return;
+				}
+				looper.fun(self._skipThresholdTime - 1);
+			}, 1);
+		});
+	});
+
 	it("can start/stop", function (done: any) {
 		var amflow = new MockAmflow();
 		var platform = new mockpf.Platform({});

--- a/spec/src/GameLoopSpec.ts
+++ b/spec/src/GameLoopSpec.ts
@@ -299,7 +299,7 @@ describe("GameLoop", function () {
 			}, 1);
 		});
 
-		amflow.sendTick([20]); // 新しいtickを送信
+		amflow.sendTick([11]); // 新しいtickを送信
 
 		// 最新の状態まで追いつく
 		await new Promise((resolve, reject) => {
@@ -308,7 +308,7 @@ describe("GameLoop", function () {
 				skipCalled = true;
 			});
 			const timer = setInterval(() => {
-				if (game.age > 20) {
+				if (game.age > 11) {
 					expect(skipCalled).toBe(true); // skippingChangedTrigger が呼ばれていることを確認
 					clearInterval(timer);
 					resolve();
@@ -318,7 +318,7 @@ describe("GameLoop", function () {
 			}, 1);
 		});
 
-		amflow.sendTick([30]); // 新しいtickを送信
+		amflow.sendTick([12]); // 新しいtickを送信
 
 		// 最新の状態まで追いつく
 		await new Promise((resolve, reject) => {
@@ -327,7 +327,7 @@ describe("GameLoop", function () {
 				skipCalled = true;
 			});
 			const timer = setInterval(() => {
-				if (game.age > 30) {
+				if (game.age > 12) {
 					expect(skipCalled).toBe(false); // skippingChangedTrigger が呼ばれていないことを確認
 					clearInterval(timer);
 					resolve();

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -563,12 +563,13 @@ export class GameLoop {
 		let sceneChanged = false;
 		const game = this._game;
 
-		if (!this._skipping && frameArg.deltaTime > this._skipThresholdTime)
+		if (!this._skipping && frameArg.deltaTime > this._skipThresholdTime) {
 			this._startSkipping();
+			if (this._waitingNextTick)
+				this._stopSkipping();
+		}
 
 		if (this._waitingNextTick) {
-			if (this._skipping)
-				this._stopSkipping();
 			if (this._sceneLocalMode === g.LocalTickMode.InterpolateLocal)
 				this._doLocalTick();
 			return;

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -563,8 +563,11 @@ export class GameLoop {
 		let sceneChanged = false;
 		const game = this._game;
 
+		// NOTE: ブラウザが長時間非アクティブ状態 (裏タブに遷移していたなど) であったとき、長時間ゲームループが呼ばれないケースがある。
+		// もしその期間がスキップの閾値を超えていたら、即座にスキップに入る。
 		if (!this._skipping && frameArg.deltaTime > this._skipThresholdTime) {
 			this._startSkipping();
+			// ただしティック待ちが無ければすぐにスキップを抜ける。
 			if (this._waitingNextTick)
 				this._stopSkipping();
 		}


### PR DESCRIPTION
## このPullRequestが解決する内容
pdi 層から looper が長時間呼ばれなかった場合 (e.g: ウェブブラウザにおいてタブをバックグラウンドに長時間切り替えていたなど) 、その後 looper が再開された際に skip threshold を超えていたら skip 扱いとするように修正します。

### TODO
 - [x] ~テスト追加~