### PR TITLE
Don't mask event flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.9.1
+* playlog の eventFlags の値をマスクしないように修正
+
 ## 1.9.0
 * @akashic/amflowと@akashic/playlogのmajor更新に伴うバージョンアップ
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/src/EventConverter.ts
+++ b/src/EventConverter.ts
@@ -32,8 +32,7 @@ export class EventConverter {
 
 		var eventCode = pev[EventIndex.General.Code];
 		// TODO: transient event 対応
-		var prio = pev[EventIndex.General.EventFlags] != null ? pl.EventFlagsMask.Priority & pev[EventIndex.General.EventFlags]
-		                                                      : pev[EventIndex.General.EventFlags];
+		var prio = pev[EventIndex.General.EventFlags];
 		var playerId = pev[EventIndex.General.PlayerId];
 		var player = this._playerTable[playerId] || { id: playerId };
 		switch (eventCode) {
@@ -142,7 +141,7 @@ export class EventConverter {
 	toPlaylogEvent(e: g.Event, preservePlayer?: boolean): pl.Event {
 		var targetId: number;
 		var playerId: string;
-		var priority = e.priority != null ? pl.EventFlagsMask.Priority & e.priority : e.priority;
+		var priority = e.priority; // NOTE: このレイヤーでは priority (eventFlags) の中身を精査しないこととする
 		switch (e.type) {
 		case g.EventType.Join:
 		case g.EventType.Leave:


### PR DESCRIPTION
## このPullRequestが解決する内容
playlog <-> g.Event の変換処理において evenfFlags (旧 priority) をマスクしないように修正します。