### PR TITLE
fix: support PlayerInfoEvent in isEventLocal()

### DIFF
--- a/spec/src/EventBufferSpec.ts
+++ b/spec/src/EventBufferSpec.ts
@@ -505,6 +505,18 @@ describe("EventBuffer", function () {
 		le.push(true);
 		expect(!!EventBuffer.isEventLocal(le)).toBe(true);
 
+		// Timestamp: Code, Priority, PlayerId, Timestamp, Local
+		var tse: pl.TimestampEvent = [ pl.EventCode.Timestamp, 0, "dummyPid", 12345];
+		expect(!!EventBuffer.isEventLocal(tse)).toBe(false);
+		tse.push(true);
+		expect(!!EventBuffer.isEventLocal(tse)).toBe(true);
+
+		// PlayerInfo: Code, Priority, PlayerId, PlayerName, UserData, Local
+		var pie: pl.PlayerInfoEvent = [ pl.EventCode.PlayerInfo, 0, "dummyPid", "dummyPlayerName", {}];
+		expect(!!EventBuffer.isEventLocal(pie)).toBe(false);
+		pie.push(true);
+		expect(!!EventBuffer.isEventLocal(pie)).toBe(true);
+
 		// Message: Code, Priority, PlayerId, Message, Local
 		var msge: pl.MessageEvent = [ pl.EventCode.Message, 0, "dummyPid", "Message"];
 		expect(!!EventBuffer.isEventLocal(msge)).toBe(false);

--- a/src/EventBuffer.ts
+++ b/src/EventBuffer.ts
@@ -87,6 +87,8 @@ export class EventBuffer implements pdi.PlatformEventHandler {
 			return pev[g.EventIndex.Leave.Local];
 		case pl.EventCode.Timestamp:
 			return pev[g.EventIndex.Timestamp.Local];
+		case pl.EventCode.PlayerInfo:
+			return pev[g.EventIndex.PlayerInfo.Local];
 		case pl.EventCode.Message:
 			return pev[g.EventIndex.Message.Local];
 		case pl.EventCode.PointDown:


### PR DESCRIPTION
掲題どおり。

未対応であることに気づいたので実装を加えます。
ついでに `TimestampEvent` のテストも一部なかったので追加しました。
