### PR TITLE
Fix build script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.10.1
+* `build` ディレクトリ以下のビルド成果物が壊れていたバグの修正
+
 ## 1.10.0
 * @akashic/amflowのmajor更新と@akashic/playlogのminor更新に伴うバージョンアップ
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ver": "tsc --version",
     "clean": "rm -rf lib/ && rm -rf spec/lib/ spec/helpers/lib/",
     "build": "tsc -p ./src/ && npm run browserify",
-    "browserify": "shx mkdir -p build && browserify -r ./lib/index.js:@akashic/game-driver -x ./node_modules/@akashic/akashic-engine/lib/main.node.js -o build/game-driver.js && npm run browserify:ae",
+    "browserify": "shx mkdir -p build && browserify -r ./lib/index.js:@akashic/game-driver -x @akashic/akashic-engine -o build/game-driver.js && npm run browserify:ae",
     "browserify:ae": "browserify -r ./node_modules/@akashic/akashic-engine/lib/main.node.js:@akashic/akashic-engine  -o build/akashic-engine.js",
     "lint": "npm run lint:ts && npm run lint:md",
     "lint:ts": "tslint src/*.ts src/auxiliary/*.ts spec/src/*.ts spec/helpers/src/*.ts",


### PR DESCRIPTION
## このPullRequestが解決する内容
`build` 以下のビルド成果物が壊れていたバグを修正します。

## 動作確認
本修正後、適当なブラウザ (`require()` が存在しない環境) で `require("@akashic/game-driver")` がエラー無く実行できることを確認。

```html
<!DOCTYPE html>
<html lang="ja">
  <head>
    <meta charset="UTF-8">
    <title>no title</title>
  </head>
  <body>
    <script src="./build/akashic-engine.js"></script>
    <script src="./build/game-driver.js"></script>
  </body>
</html>
```