### PR TITLE
ignorable イベントに対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## unreleased changes
+* @akashic/amflow@3.0.0 に対応
+
 ## 2.0.3
 * @akashic/game-configuration@1.0.1 に追従
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.1.0-beta.0",
+  "version": "2.1.0-beta.1",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/spec/src/GameLoopSpec.ts
+++ b/spec/src/GameLoopSpec.ts
@@ -515,10 +515,18 @@ describe("GameLoop", function () {
 						expect(self.getCurrentTime() < 3000 + startedAt + self._frameTime * 2).toBe(true);
 
 						clearInterval(timer);
-						expect(spyOnGetTickList.calls.count()).toBe(1);
+						expect(spyOnGetTickList.calls.count()).toBe(2); // 初回の読み込み + 等倍に戻ったタイミングでのティック再取得
 						expect(spyOnGetTickList.calls.argsFor(0)[0]).toEqual({
 							begin: 0,
-							end: TickBuffer.DEFAULT_SIZE_REQUEST_ONCE
+							end: TickBuffer.DEFAULT_SIZE_REQUEST_ONCE,
+							excludeEventFlags: {
+								ignorable: true
+							}
+						});
+						// tick 3 に到達した時点で後続ティックを取得し直しているはず
+						expect(spyOnGetTickList.calls.argsFor(1)[0]).toEqual({
+							begin: 3,
+							end: TickBuffer.DEFAULT_SIZE_REQUEST_ONCE + 3
 						});
 						expect(passedTestAges).toEqual([4, 6]);
 						expect(timeReachedCount).toBe(3);

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -679,11 +679,7 @@ export class GameLoop {
 				this._omittedTickDuration = 0;
 			} else {
 				// 時間は経過しているが消費すべきティックが届いていない
-				if (this._skipping) {
-					this._tickBuffer.requestNonIgnorableTicks();
-				} else {
-					this._tickBuffer.requestTicks();
-				}
+				this._tickBuffer.requestTicks();
 				this._startWaitingNextTick();
 				break;
 			}

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -533,7 +533,7 @@ export class GameLoop {
 		if (this._skipping && (targetTime - this._currentTime < this._frameTime)) {
 			this._stopSkipping();
 			// スキップ状態が解除された (≒等倍に戻った) タイミングで改めてすべてのティックを取得し直す
-			this._tickBuffer._dropAll();
+			this._tickBuffer.dropAll();
 			this._tickBuffer.requestTicks();
 		}
 	}

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -300,6 +300,7 @@ export class GameLoop {
 	_startSkipping(): void {
 		this._skipping = true;
 		this._updateGamePlaybackRate();
+		this._tickBuffer.startSkipping();
 		this._game.skippingChangedTrigger.fire(true);
 	}
 
@@ -309,6 +310,7 @@ export class GameLoop {
 	_stopSkipping(): void {
 		this._skipping = false;
 		this._updateGamePlaybackRate();
+		this._tickBuffer.endSkipping();
 		this._game.skippingChangedTrigger.fire(false);
 	}
 
@@ -439,7 +441,7 @@ export class GameLoop {
 				if (!this._waitingNextTick) {
 					this._startWaitingNextTick();
 					if (!this._consumedLatestTick)
-						this._tickBuffer.requestTicks();
+						this._tickBuffer.prefetchTicks();
 				}
 				if (this._omitInterpolatedTickOnReplay && this._sceneLocalMode === "interpolate-local") {
 					if (this._consumedLatestTick) {
@@ -528,8 +530,12 @@ export class GameLoop {
 			}
 		}
 
-		if (this._skipping && (targetTime - this._currentTime < this._frameTime))
+		if (this._skipping && (targetTime - this._currentTime < this._frameTime)) {
 			this._stopSkipping();
+			// スキップ状態が解除された (≒等倍に戻った) タイミングで改めてすべてのティックを取得し直す
+			this._tickBuffer._dropAll();
+			this._tickBuffer.requestTicks();
+		}
 	}
 
 	/**
@@ -603,7 +609,7 @@ export class GameLoop {
 					// NOTE: Manualのシーンでは age=1 のティックが長時間受信できない場合がある。(TickBuffer#addTick()が呼ばれない)
 					// そのケースでは最初のティックの受信にポーリング時間(初期値: 10秒)かかってしまうため、ここで最新ティックを要求する。
 					// (初期シーンがNonLocalであってもティックの進行によりManualのシーンに移行してしまう可能性があるため、常に最新のティックを要求している。)
-					this._tickBuffer.requestTicks(undefined, undefined, { ignorable: true });
+					this._tickBuffer.prefetchTicks();
 				}
 				// 既知最新ティックに追いついたので、ポーリング処理により後続ティックを要求する。
 				// NOTE: Manualのシーンでは最新ティックの生成そのものが長時間起きない可能性がある。
@@ -673,7 +679,7 @@ export class GameLoop {
 				this._omittedTickDuration = 0;
 			} else {
 				// 時間は経過しているが消費すべきティックが届いていない
-				this._tickBuffer.requestTicks(undefined, undefined, { ignorable: true });
+				this._tickBuffer.requestTicks();
 				this._startWaitingNextTick();
 				break;
 			}

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -441,7 +441,7 @@ export class GameLoop {
 				if (!this._waitingNextTick) {
 					this._startWaitingNextTick();
 					if (!this._consumedLatestTick)
-						this._tickBuffer.prefetchTicks();
+						this._tickBuffer.requestNonIgnorableTicks();
 				}
 				if (this._omitInterpolatedTickOnReplay && this._sceneLocalMode === "interpolate-local") {
 					if (this._consumedLatestTick) {
@@ -609,7 +609,7 @@ export class GameLoop {
 					// NOTE: Manualのシーンでは age=1 のティックが長時間受信できない場合がある。(TickBuffer#addTick()が呼ばれない)
 					// そのケースでは最初のティックの受信にポーリング時間(初期値: 10秒)かかってしまうため、ここで最新ティックを要求する。
 					// (初期シーンがNonLocalであってもティックの進行によりManualのシーンに移行してしまう可能性があるため、常に最新のティックを要求している。)
-					this._tickBuffer.prefetchTicks();
+					this._tickBuffer.requestNonIgnorableTicks();
 				}
 				// 既知最新ティックに追いついたので、ポーリング処理により後続ティックを要求する。
 				// NOTE: Manualのシーンでは最新ティックの生成そのものが長時間起きない可能性がある。

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -679,7 +679,11 @@ export class GameLoop {
 				this._omittedTickDuration = 0;
 			} else {
 				// 時間は経過しているが消費すべきティックが届いていない
-				this._tickBuffer.requestTicks();
+				if (this._skipping) {
+					this._tickBuffer.requestNonIgnorableTicks();
+				} else {
+					this._tickBuffer.requestTicks();
+				}
 				this._startWaitingNextTick();
 				break;
 			}

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -188,11 +188,7 @@ export class TickBuffer {
 			++range.start;
 
 			if (age + this._prefetchThreshold === this._nearestAbsentAge) {
-				if (this._skipping) {
-					this.requestNonIgnorableTicks(this._nearestAbsentAge, this._sizeRequestOnce);
-				} else {
-					this.requestTicks(this._nearestAbsentAge, this._sizeRequestOnce);
-				}
+				this.requestTicks(this._nearestAbsentAge, this._sizeRequestOnce);
 			}
 			if (range.start === range.end)
 				this._tickRanges.shift();
@@ -242,6 +238,14 @@ export class TickBuffer {
 	}
 
 	requestTicks(from: number = this.currentAge, len: number = this._sizeRequestOnce): void {
+		if (this._skipping) {
+			this.requestNonIgnorableTicks(from, len);
+		} else {
+			this.requestAllTicks(from, len);
+		}
+	}
+
+	requestAllTicks(from: number = this.currentAge, len: number = this._sizeRequestOnce): void {
 		if (this._executionMode !== ExecutionMode.Passive)
 			return;
 		this._amflow.getTickList({ begin: from, end: from + len }, this._onTicks_bound);

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -190,9 +190,9 @@ export class TickBuffer {
 
 			if (age + this._prefetchThreshold === this._nearestAbsentAge) {
 				if (this._skipping) {
-					this.requestTicks(this._nearestAbsentAge, this._sizeRequestOnce);
-				} else {
 					this.requestNonIgnorableTicks(this._nearestAbsentAge, this._sizeRequestOnce);
+				} else {
+					this.requestTicks(this._nearestAbsentAge, this._sizeRequestOnce);
 				}
 			}
 			if (range.start === range.end)

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -192,7 +192,7 @@ export class TickBuffer {
 				if (this._skipping) {
 					this.requestTicks(this._nearestAbsentAge, this._sizeRequestOnce);
 				} else {
-					this.prefetchTicks(this._nearestAbsentAge, this._sizeRequestOnce);
+					this.requestNonIgnorableTicks(this._nearestAbsentAge, this._sizeRequestOnce);
 				}
 			}
 			if (range.start === range.end)
@@ -248,7 +248,7 @@ export class TickBuffer {
 		this._amflow.getTickList({ begin: from, end: from + len }, this._onTicks_bound);
 	}
 
-	prefetchTicks(from: number = this.currentAge, len: number = this._sizeRequestOnce): void {
+	requestNonIgnorableTicks(from: number = this.currentAge, len: number = this._sizeRequestOnce): void {
 		if (this._executionMode !== ExecutionMode.Passive)
 			return;
 		this._amflow.getTickList({ begin: from, end: from + len, excludeEventFlags: { ignorable: true } }, this._onTicks_bound);

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -2,7 +2,6 @@
 import * as pl from "@akashic/playlog";
 import { AMFlow } from "@akashic/amflow";
 import * as g from "@akashic/akashic-engine";
-import ExcludeEventFlags from "./ExcludeEventFlags";
 import ExecutionMode from "./ExecutionMode";
 import StorageOnTick from "./StorageOnTick";
 

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -383,6 +383,10 @@ export class TickBuffer {
 		return tickRange;
 	}
 
+	dropAll(): void {
+		this._tickRanges = [];
+	}
+
 	_updateAmflowReceiveState(): void {
 		if (this._receiving && this._executionMode === ExecutionMode.Passive) {
 			this._amflow.onTick(this._addTick_bound);
@@ -445,10 +449,6 @@ export class TickBuffer {
 				break;
 		}
 		range.ticks = range.ticks.slice(i);
-	}
-
-	_dropAll(): void {
-		this._tickRanges = [];
 	}
 
 	private _createTickRangeFromTick(tick: pl.Tick): TickRange {


### PR DESCRIPTION
## このPullRequestが解決する内容
[ignorable イベント](https://github.com/akashic-games/playlog/pull/8) に対応します。

### ignorable イベント
「リプレイする上で必ずしも再現する必要のないイベント」と定義しています。game-driver においてはスキップ中に除外することを試みます。ただし、条件によってはスキップ中でも ignorable イベントを含むティックが消化されることがあります (e.g. 既に ignorable イベントを取得済みの場合に未来にシークした場合など)。

## 挙動

### リアルタイム再生時
最新に追いつくまで ignorable イベントを除外したティックを消化します。

### リプレイ再生時
1. 最初に ignorable イベントを除外した状態のティックを取得します。
2. シーク位置 (目標時刻) に到達したら手持ちのティックを削除し、ignorable イベントを含めたティックを取得します。

## 動作確認

### 等倍のリプレイ再生から途中にシークした際の挙動

![ignorable-1](https://user-images.githubusercontent.com/16933898/109743042-65425180-7c13-11eb-8575-57889f2badee.png)
