### PR TITLE
TickBuffer#dropAll() の呼び出し時に内部状態をリセットするように修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.1.0-beta.1",
+  "version": "2.1.0-beta.2",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -177,7 +177,7 @@ export class TickBuffer {
 	}
 
 	consume(): pl.Tick | number | null {
-		if (this.currentAge === this._nearestAbsentAge)
+		if (this.currentAge === this._nearestAbsentAge || !this._tickRanges.length)
 			return null;
 		const age = this.currentAge;
 		let range = this._tickRanges[0];

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -177,7 +177,7 @@ export class TickBuffer {
 	}
 
 	consume(): pl.Tick | number | null {
-		if (this.currentAge === this._nearestAbsentAge || !this._tickRanges.length)
+		if (this.currentAge === this._nearestAbsentAge)
 			return null;
 		const age = this.currentAge;
 		let range = this._tickRanges[0];
@@ -388,6 +388,8 @@ export class TickBuffer {
 
 	dropAll(): void {
 		this._tickRanges = [];
+		this._nearestAbsentAge = this.currentAge;
+		this._nextTickTimeCache = null;
 	}
 
 	_updateAmflowReceiveState(): void {


### PR DESCRIPTION
## このPullRequestが解決する内容
`TickBuffer#dropAll()` の呼び出し時に `TickBuffer#currentTime` と `TickBuffer#_nearestAbsentAge` の値をリセットするように修正します。それにより `TickBuffer#consume()` の呼び出し時に `TickBuffer#currentAge !== TickBuffer#_nearestAbsentAge` かつ `TickBuffer#_tickRanges.length === 0` というケース (e.g. 追っかけ再生時にちょうどティックの直前あたりにシークした際など) が発生し、ランタイムエラーとなっていた問題を修正します。