### PR TITLE
revert: use deprecated interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.1.1
+* `TickBuffer#requestTicks()` で @akashic/amflow@2 以前の `AMFlow#getTickList()` の引数を利用するように差し戻し
+
 ## 2.1.0
 * @akashic/amflow@3.0.0 に対応
 * ignorable event に対応

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/spec/src/GameLoopSpec.ts
+++ b/spec/src/GameLoopSpec.ts
@@ -516,18 +516,11 @@ describe("GameLoop", function () {
 
 						clearInterval(timer);
 						expect(spyOnGetTickList.calls.count()).toBe(2); // 初回の読み込み + 等倍に戻ったタイミングでのティック再取得
-						expect(spyOnGetTickList.calls.argsFor(0)[0]).toEqual({
-							begin: 0,
-							end: TickBuffer.DEFAULT_SIZE_REQUEST_ONCE,
-							excludeEventFlags: {
-								ignorable: true
-							}
-						});
+						expect(spyOnGetTickList.calls.argsFor(0)[0]).toBe(0);
+						expect(spyOnGetTickList.calls.argsFor(0)[1]).toBe(TickBuffer.DEFAULT_SIZE_REQUEST_ONCE);
 						// tick 3 に到達した時点で後続ティックを取得し直しているはず
-						expect(spyOnGetTickList.calls.argsFor(1)[0]).toEqual({
-							begin: 3,
-							end: TickBuffer.DEFAULT_SIZE_REQUEST_ONCE + 3
-						});
+						expect(spyOnGetTickList.calls.argsFor(1)[0]).toBe(3);
+						expect(spyOnGetTickList.calls.argsFor(1)[1]).toBe(TickBuffer.DEFAULT_SIZE_REQUEST_ONCE + 3);
 						expect(passedTestAges).toEqual([4, 6]);
 						expect(timeReachedCount).toBe(3);
 						expect(skippingTestState).toBe(2);

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -248,13 +248,19 @@ export class TickBuffer {
 	requestAllTicks(from: number = this.currentAge, len: number = this._sizeRequestOnce): void {
 		if (this._executionMode !== ExecutionMode.Passive)
 			return;
-		this._amflow.getTickList({ begin: from, end: from + len }, this._onTicks_bound);
+		// NOTE: 移行期のため一時的に旧インタフェースを利用する
+		this._amflow.getTickList(from, from + len, this._onTicks_bound);
+		// TODO: AMFlow@3.0.0 の引数を利用するように変更する
+		// this._amflow.getTickList({ begin: from, end: from + len }, this._onTicks_bound);
 	}
 
 	requestNonIgnorableTicks(from: number = this.currentAge, len: number = this._sizeRequestOnce): void {
 		if (this._executionMode !== ExecutionMode.Passive)
 			return;
-		this._amflow.getTickList({ begin: from, end: from + len, excludeEventFlags: { ignorable: true } }, this._onTicks_bound);
+		// NOTE: 移行期のため一時的に旧インタフェースを利用する
+		this._amflow.getTickList(from, from + len, this._onTicks_bound);
+		// TODO: AMFlow@3.0.0 の引数を利用するように変更する
+		// this._amflow.getTickList({ begin: from, end: from + len, excludeEventFlags: { ignorable: true } }, this._onTicks_bound);
 	}
 
 	addTick(tick: pl.Tick): void {


### PR DESCRIPTION
# このPullRequestが解決する内容
過渡期のため、一時的に `TickBuffer#requestTicks()` 内で @akashic/amflow@2 以前の `AMFlow#getTickList()` の引数を利用するように差し戻します。

akashic-cli-serve@1.5.4 にて動作確認済みです。