### PR TITLE
fix: update TickBuffer#knownLatestAge in setCurrentAge()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## (unreleased changes)
+* スナップショットで外部からリセットした場合に、`TickBuffer#knownLatestAge` が更新されない問題を修正
+
 ## 2.4.2
 * `MemoryAmflowClient`, `ReplayAmflowProxy` を削除し @akashic/amflow-util を利用するように
 

--- a/spec/src/TickBufferSpec.ts
+++ b/spec/src/TickBufferSpec.ts
@@ -190,6 +190,7 @@ describe("TickBuffer", function() {
 		// age 7 に飛ぶと age 4 が ticks から消える
 		tb.setCurrentAge(7);
 		expect(tb.currentAge).toBe(7);
+		expect(tb.knownLatestAge).toBe(20);
 		expect(tb._nearestAbsentAge).toBe(21);
 		expect(tb._tickRanges).toEqual([
 			{ start: 7, end: 21, ticks: [[10, [msg0]]] }
@@ -198,10 +199,12 @@ describe("TickBuffer", function() {
 		// 何もないところまで飛ぶと全部消える
 		tb.setCurrentAge(100);
 		expect(tb.currentAge).toBe(100);
+		expect(tb.knownLatestAge).toBe(99);
 		expect(tb._nearestAbsentAge).toBe(100);
 		expect(tb._tickRanges).toEqual([]);
 		tb._onTicks(null, [ 100, 100, null ]);
 		expect(tb.currentAge).toBe(100);
+		expect(tb.knownLatestAge).toBe(100);
 		expect(tb._nearestAbsentAge).toBe(101);
 		expect(tb._tickRanges).toEqual([
 			{ start: 100, end: 101, ticks: [] }
@@ -217,6 +220,7 @@ describe("TickBuffer", function() {
 			45, 60, [[49, [pd0]], [51, [msg0, pd0]], [52, [msg0]]]
 		]);
 		expect(tb.currentAge).toBe(101);
+		expect(tb.knownLatestAge).toBe(100);
 		expect(tb._nearestAbsentAge).toBe(101);
 		expect(tb._tickRanges).toEqual([
 			{ start: 3, end: 21, ticks: [[4, [pd0]], [10, [msg0]]] },
@@ -226,6 +230,7 @@ describe("TickBuffer", function() {
 		// currentAgeを2まで戻すと足したtickを消化できる
 		tb.setCurrentAge(2);
 		expect(tb.currentAge).toBe(2);
+		expect(tb.knownLatestAge).toBe(100); // 上がった knownLatestAge は下がらない
 		expect(tb._nearestAbsentAge).toBe(2);
 		tb.setCurrentAge(19);
 		expect(tb.currentAge).toBe(19);

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -72,7 +72,7 @@ export class TickBuffer {
 
 	/**
 	 * 既知の最新age。
-	 * AMFlow から受け取った限りで最後のage。
+	 * AMFlow から受け取った、または setCurrentAge() で外部から存在を示された最新の age 。
 	 */
 	knownLatestAge: number = -1;
 
@@ -162,10 +162,18 @@ export class TickBuffer {
 		this._updateAmflowReceiveState();
 	}
 
+	/**
+	 * currentAge を設定する。
+	 *
+	 * 引数は存在することがわかっている age でなければならない。
+	 * (Realtime モードの tick/StartPoint 取得の基準となる knownLatestAge も更新するため)
+	 */
 	setCurrentAge(age: number): void {
 		this._dropUntil(age);
 		this._nextTickTimeCache = null;
 		this.currentAge = age;
+		if (this.knownLatestAge < age - 1)
+			this.knownLatestAge = age - 1;
 		this._nearestAbsentAge = this._findNearestAbscentAge(age);
 	}
 


### PR DESCRIPTION
掲題どおり。 `TickBuffer#setCurrentAge()` で `currentAge` を更新する際、 `knownLatestAge` (既知の最新 age) の更新が漏れていました。

この影響で、最新の tick の消化を目指す `Realtime` モードの動作に支障が出る場合があります。「最新」の基準としてこの `knownLatestAge` を参照するためです。この値を更新しそこなうと「実行開始前に `setCurrentAge()` で現在 age を進めたにも関わらず、(更新されていない)  `knownLatestAge` を参照して age: 0 に戻ってしまい、そこから改めて最新を目指す」現象が発生します。これを修正します。

なおこの現象は、以下の両方を満たす時にのみ発生します。

- (a) このインスタンスの既知の最新 tick よりも未来に `setCurrentAge()` している場合
- (b) tick の push 通知が受け取れなかった場合
   - (アクティブインスタンスが一時停止している、存在しない、または遅延で受信が遅れたなど)

従来は (a) の条件を満たすことがありませんでした。スナップショットによって (a) を満たす「スナップショットから実行を開始する」ケースが生まれたために露見しました。

ユニットテストの追加のほか、 akashic-cli@2.11.5 の serve に組み込み、この処理を利用するパスの動作を目視確認しています。実際にはさらに別件の問題が現れますが、そちらは別 PR で対応します。
