### PR TITLE
fix: fix handling the latest tick. introduce _foundLatestTick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## (unreleased changes)
 * スナップショットで外部からリセットした場合に、`TickBuffer#knownLatestAge` が更新されない問題を修正
+* スナップショットで外部からリセットした場合に、しばらくゲームが開始されない問題を修正
+* リプレイ再生時、無駄なティック取得を行う場合がある問題を修正
 
 ## 2.4.2
 * `MemoryAmflowClient`, `ReplayAmflowProxy` を削除し @akashic/amflow-util を利用するように

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## (unreleased changes)
+* スナップショットで外部からリセットした場合に、`TickBuffer#knownLatestAge` が更新されない問題を修正
+
 ## 2.4.2
 * `MemoryAmflowClient`, `ReplayAmflowProxy` を削除し @akashic/amflow-util を利用するように
 

--- a/spec/src/GameLoopSpec.ts
+++ b/spec/src/GameLoopSpec.ts
@@ -280,8 +280,6 @@ describe("GameLoop", function () {
 		});
 		self.start();
 
-		// amflow.sendTick([10]); // Realtimeで非Manualなのでtickをpushされないと何も動かない
-
 		const looper = self._clock._looper as mockpf.Looper;
 		game._reset({ age: 0, randSeed: 0 });
 		game._loadAndStart({ args: undefined });
@@ -980,7 +978,7 @@ describe("GameLoop", function () {
 							}
 						} else {
 							// 本題1: 一度立った _foundLatestTick が落ちていないことを確認
-							expect(self._foundLatestTick).toBe(true);  // TODO --!
+							expect(self._foundLatestTick).toBe(true);
 
 							// skip 終了時の tick 取得が起きて +1 回増える
 							expect(spyOnGetTickList.mock.calls.length).toBe(3);

--- a/spec/src/TickBufferSpec.ts
+++ b/spec/src/TickBufferSpec.ts
@@ -190,6 +190,7 @@ describe("TickBuffer", function() {
 		// age 7 に飛ぶと age 4 が ticks から消える
 		tb.setCurrentAge(7);
 		expect(tb.currentAge).toBe(7);
+		expect(tb.knownLatestAge).toBe(20);
 		expect(tb._nearestAbsentAge).toBe(21);
 		expect(tb._tickRanges).toEqual([
 			{ start: 7, end: 21, ticks: [[10, [msg0]]] }
@@ -198,10 +199,12 @@ describe("TickBuffer", function() {
 		// 何もないところまで飛ぶと全部消える
 		tb.setCurrentAge(100);
 		expect(tb.currentAge).toBe(100);
+		expect(tb.knownLatestAge).toBe(99);
 		expect(tb._nearestAbsentAge).toBe(100);
 		expect(tb._tickRanges).toEqual([]);
 		tb._onTicks(null, [ 100, 100, null ]);
 		expect(tb.currentAge).toBe(100);
+		expect(tb.knownLatestAge).toBe(100);
 		expect(tb._nearestAbsentAge).toBe(101);
 		expect(tb._tickRanges).toEqual([
 			{ start: 100, end: 101, ticks: [] }
@@ -217,6 +220,7 @@ describe("TickBuffer", function() {
 			45, 60, [[49, [pd0]], [51, [msg0, pd0]], [52, [msg0]]]
 		]);
 		expect(tb.currentAge).toBe(101);
+		expect(tb.knownLatestAge).toBe(100);
 		expect(tb._nearestAbsentAge).toBe(101);
 		expect(tb._tickRanges).toEqual([
 			{ start: 3, end: 21, ticks: [[4, [pd0]], [10, [msg0]]] },
@@ -226,6 +230,7 @@ describe("TickBuffer", function() {
 		// currentAgeを2まで戻すと足したtickを消化できる
 		tb.setCurrentAge(2);
 		expect(tb.currentAge).toBe(2);
+		expect(tb.knownLatestAge).toBe(100); // 上がった knownLatestAge は下がらない
 		expect(tb._nearestAbsentAge).toBe(2);
 		tb.setCurrentAge(19);
 		expect(tb.currentAge).toBe(19);

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -104,7 +104,16 @@ export class GameLoop {
 	_lastRequestedStartPointAge: number = -1;
 	_lastRequestedStartPointTime: number = -1;
 	_waitingNextTick: boolean = false;
+
+	/**
+	 * reset() 後、一度でも最新 (既知最新でなく実際の最新と思われる) tick を見つけたか。
+	 *
+	 * この値が偽である場合、受信できていない後続 tick が存在する可能性がある。
+	 * 真ならば、以降の tick はすべて AMFlow#onTick() で受け取るはずなので、後続を探すための tick リクエストが不要になる。
+	 * (なお一部の異常系ではこの値が真でも後続 tick を見落としている可能性があるが、その場合はポーリング処理で救うことにする)
+	 */
 	_foundLatestTick: boolean = false;
+
 	_skipping: boolean = false;
 	_lastPollingTickTime: number = 0;
 

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -104,7 +104,7 @@ export class GameLoop {
 	_lastRequestedStartPointAge: number = -1;
 	_lastRequestedStartPointTime: number = -1;
 	_waitingNextTick: boolean = false;
-	_consumedLatestTick: boolean = false;
+	_foundLatestTick: boolean = false;
 	_skipping: boolean = false;
 	_lastPollingTickTime: number = 0;
 
@@ -206,7 +206,7 @@ export class GameLoop {
 		this._tickBuffer.setCurrentAge(startPoint.frame);
 		this._currentTime = startPoint.timestamp || startPoint.data.timestamp || 0;  // data.timestamp は後方互換性のために存在。現在は使っていない。
 		this._waitingNextTick = false; // 現在ageを変えた後、さらに後続のTickが足りないかどうかは_onFrameで判断する。
-		this._consumedLatestTick = false; // 同上。
+		this._foundLatestTick = false; // 同上。
 		this._lastRequestedStartPointAge = -1;  // 現在ageを変えた時はリセットしておく(場合によっては不要だが、安全のため)。
 		this._lastRequestedStartPointTime = -1;  // 同上。
 		this._omittedTickDuration = 0;
@@ -448,7 +448,7 @@ export class GameLoop {
 
 		if (!this._skipping) {
 			if ((frameGap > this._skipThreshold || this._tickBuffer.currentAge === 0) &&
-			    (this._tickBuffer.hasNextTick() || (this._omitInterpolatedTickOnReplay && this._consumedLatestTick))) {
+			    (this._tickBuffer.hasNextTick() || (this._omitInterpolatedTickOnReplay && this._foundLatestTick))) {
 				// ここでは常に `frameGap > 0` であることに注意。0の時にskipに入ってもすぐ戻ってしまう
 				this._startSkipping();
 			}
@@ -460,11 +460,11 @@ export class GameLoop {
 			if (!this._tickBuffer.hasNextTick()) {
 				if (!this._waitingNextTick) {
 					this._startWaitingNextTick();
-					if (!this._consumedLatestTick)
+					if (!this._foundLatestTick)
 						this._tickBuffer.requestNonIgnorableTicks();
 				}
 				if (this._omitInterpolatedTickOnReplay && this._sceneLocalMode === "interpolate-local") {
-					if (this._consumedLatestTick) {
+					if (this._foundLatestTick) {
 						// 最新のティックが存在しない場合は現在時刻を目標時刻に合わせる。
 						// (_doLocalTick() により現在時刻が this._frameTime 進むのでその直前まで進める)
 						this._currentTime = targetTime - this._frameTime;
@@ -625,10 +625,9 @@ export class GameLoop {
 
 		if (ageGap <= 0) {
 			if (ageGap === 0) {
-				if (currentAge === 0) {
-					// NOTE: Manualのシーンでは age=1 のティックが長時間受信できない場合がある。(TickBuffer#addTick()が呼ばれない)
-					// そのケースでは最初のティックの受信にポーリング時間(初期値: 10秒)かかってしまうため、ここで最新ティックを要求する。
-					// (初期シーンがNonLocalであってもティックの進行によりManualのシーンに移行してしまう可能性があるため、常に最新のティックを要求している。)
+				if (!this._foundLatestTick) {
+					// NOTE: Manualのシーンやアクティブインスタンスがポーズしている状況では、後続のティックが長時間受信できない場合がある。(TickBuffer#addTick()が呼ばれない)
+					// そのケースでは後続ティックの受信にポーリングの単位時間(初期値: 10秒)かかってしまうため、ここで最新ティックを要求する。
 					this._tickBuffer.requestNonIgnorableTicks();
 				}
 				// 既知最新ティックに追いついたので、ポーリング処理により後続ティックを要求する。
@@ -724,7 +723,6 @@ export class GameLoop {
 	}
 
 	_onGotNextFrameTick(): void {
-		this._consumedLatestTick = false;
 		if (!this._waitingNextTick)
 			return;
 		if (this._loopMode === LoopMode.FrameByFrame) {
@@ -736,7 +734,7 @@ export class GameLoop {
 
 	_onGotNoTick(): void {
 		if (this._waitingNextTick)
-			this._consumedLatestTick = true;
+			this._foundLatestTick = true;
 	}
 
 	_onGotStartPoint(err: Error | null, startPoint?: amf.StartPoint): void {

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -72,7 +72,7 @@ export class TickBuffer {
 
 	/**
 	 * 既知の最新age。
-	 * AMFlow から受け取った限りで最後のage。
+	 * AMFlow から受け取った、または setCurrentAge() で外部から存在を示された最新の age 。
 	 */
 	knownLatestAge: number = -1;
 
@@ -162,10 +162,18 @@ export class TickBuffer {
 		this._updateAmflowReceiveState();
 	}
 
+	/**
+	 * currentAge を設定する。
+	 *
+	 * 引数は存在することがわかっている age でなければならない。
+	 * (Realtime モードの tick/StartPoint 取得の基準となる knownLatestAge も更新するため)
+	 */
 	setCurrentAge(age: number): void {
 		this._dropUntil(age);
 		this._nextTickTimeCache = null;
 		this.currentAge = age;
+		if (this.knownLatestAge < age - 1)
+			this.knownLatestAge = age - 1;
 		this._nearestAbsentAge = this._findNearestAbscentAge(age);
 	}
 


### PR DESCRIPTION
Realtime モードのパッシブインスタンスをスナップショットから開始した時、 しばらくゲームが進まない問題を解消します。

## 背景

Realtime モードは、最新 tick の受信を契機に、その最新 tick の消化を最速で目指すモードです。逆に最新 tick を受信しない限り動きません。

従来の Realtime モードは、 [実行開始直後 (`currentAge === 0` の時) に、能動的に後続 tick を取得していました][req-on-age0] (a) 。ある種の条件で、実行開始後に最新 tick が長時間受信できないケースがあったためです。しかしスナップショットから開始すると、実行開始直後であっても (`currentAge > 0` になるので) このパスに入れません。そのため最新 tick の受信が長時間起きない状況ではしばらくゲームが進まなくなりました。(ポーリング処理による tick 受信が起きる 10 秒後に動き出します)

そもそも、現在の (a) の振る舞いは正しいものではないように思えます。

というのも極端なケースでは、一度の後続 tick 要求で tick が取得しきれるとは限りません。また一度目で取得した tick の消化中に、別の最新 tick を受信できるとも限りません。そのためごく稀なケースでは `currentAge > 0` であっても後続 tick を要求しなければならないことが元々あり得ました。(現実的には、さらに [別のパス][another-req-path] での tick 要求も生じなかった時にしか問題にならないので、意図的に再現するのは非常に手間ですが)

スナップショットの導入により、その非常に稀だった問題を確実に再現できるようになったのが現状です。

[req-on-age0]: https://github.com/akashic-games/game-driver/compare/fix-known-latest-age...fix-latest-tick-handling#diff-f0b5ded32ca36c7d1e55e942ed6ab3c25eb6f1b82c9d538ada3006f25a470766L628
[another-req-path]: https://github.com/akashic-games/game-driver/blob/ad18285374ab4b024ffddf3c05f9f5a90ca34f73/src/GameLoop.ts#L701

## 検討

改めて考えると、(a) の処理で後続 tick の取得を試みねばならないのは **`reset()` 後、一度最新 tick を消化するまでの間** だけに思えます。なぜなら、一度最新 tick を消化したことが分かった場合、その後の tick はすべてプッシュ通知で受け取っているはずだからです。逆に最新を消化したと分からない限りは、後続 tick がある可能性があります (`currentAge` が 0 であってもなくても)。

現実装には、この条件に近い値として `GameLoop#_consumedLatestTick: boolean` があります。「最新 tick を消化した」という名前のとおり、この変数は以下のように設定されます:

- i) 初期状態 (`reset()` した時) で偽になる
- ii) 既知最新 tick の消化後、次の tick 取得で空を得た (本当の最新を見つけた) 時に真になる
- iii) その後に後続の tick を得たら偽に戻る (そして (ii) の条件を満たせばまた真になる)

ここから (iii) の処理をなくすと、我々がここで利用したい条件「`reset()` 後に "一度" 最新を消化したか否か」そのものになります。しかしこの `_consumedLatestTick` を、そのまま (a) の処理の条件に使うことはできません。なぜなら (iii) の動作で逐一フラグが落ちるので、最新 tick に追いついた後「1 tick 消化して後続を無駄に取得し、何も得られない」という動作を 1 tick ごとに繰り返すことになるはずだからです。

そこで **`GameLoop#_foundLatestTick: boolean`** という変数を導入します。この値は「`reset()` で偽になり、一度最新 tick を消化するとその後は真」とします。

よく見ると、現在 `_consumedLatestTick` を使っている箇所も、実際には `_foundLatestTick` を利用すべきに思えます。たとえば [リプレイ中に次の tick がなくなった時][req-tick-in-replay] に、この値を使って「最新ティックを消化していなければ」後続 tick を要求しています。しかし上述のとおり、一度でも最新に追いついたなら、その後の tick は全てプッシュ通知で受け取っているはずなので、この取得はほぼ無駄に終わります。

(例外的に、ある種の稀な異常系、すなわち「アクティブインスタンスが存在するリプレイで、通信エラーによってある時点以降すべての tick のプッシュ通知が受け取れていない (最新 tick の存在を見落としている) が、能動的にリクエストすれば取れる (通信断ではない)」状況においては、この取得が有効に働くことがあり得ます (通信断して、復旧し、その後別の最新 tick を受け取るまでの間など)。ただそれは頻発するとは思えず、ポーリング処理で救うので十分そうです)

[req-tick-in-replay]: https://github.com/akashic-games/game-driver/compare/fix-known-latest-age...fix-latest-tick-handling#diff-f0b5ded32ca36c7d1e55e942ed6ab3c25eb6f1b82c9d538ada3006f25a470766L463-L464

## 対応

以上の検討から、以下を行います。

- `GameLoop#_consumedLatestTick` を `_foundLatestTick` に改名し、後続 tick の取得時に偽にリセット "しない" ようにします
- Realtime モードの「 `currentAge === 0` では後続 tick を取得する」処理を、 「 `_foundLatestTick` でなければ後続 tick を取得する」に改めます

関連してユニットテストを追加しているほか、 akashic-cli@2.11.5 の serve に #104 と合わせて組み込み、このパスを通る動作を目視確認しています。
