### PR TITLE
fix: avoid wrong fire of TickBuffer#gotNoTickTrigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * スナップショットで外部からリセットした場合に、`TickBuffer#knownLatestAge` が更新されない問題を修正
 * スナップショットで外部からリセットした場合に、しばらくゲームが開始されない問題を修正
 * リプレイ再生時、無駄なティック取得を行う場合がある問題を修正
+* `TickBuffer#gotNoTickTrigger` の誤通知を修正 (外部への影響なし)
 
 ## 2.4.2
 * `MemoryAmflowClient`, `ReplayAmflowProxy` を削除し @akashic/amflow-util を利用するように

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -441,7 +441,7 @@ export class TickBuffer {
 		if (mayGotNext && (inserted.start <= this.currentAge && this.currentAge < inserted.end)) {
 			this.gotNextTickTrigger.fire();
 		}
-		if (!inserted.ticks.length) {
+		if (inserted.start === inserted.end) {
 			this.gotNoTickTrigger.fire();
 		}
 	}


### PR DESCRIPTION
掲題どおり。 `gotNoTickTrigger` の fire 条件に誤りがありました。修正に併せてユニットテストを追加します。(#105 の後に直すつもりでしたが、テストでこの修正を前提にしてしまったので、 #105 への PR になっています)

なおたまたまですが外部影響はないはずです。

というのも、この問題は「ティックを取得した時、"何も得られなかった時" ではなく "イベントを持つティックがなかった時" に `gotNoTickTrigger` を fire していた」ものでした。つまり「後続ティックが取得できた ("あった") のに、間違って "なかった" (no tick) と通知するケース」がありました。

一方この trigger の fire の前には `gotNextTickTrigger` の fire 処理があります。その影響で [「後続ティックがあった場合」には必ず `GameLoop#_waitingNextTick` が落ちます][wait-end] (未使用のオプション `FrameByFrame` を除き)。一方この `gotNoTickTrigger` の通知を受ける `GameLoop#_onGotNoTick()` は [「 `_waitingNextTick` ならば `_consumedLatestTick` を立てる」処理しかしていません][set-consumed]。そのため `gotNoTickTrigger` が誤通知するケースでは (正しく) なんの処理も走りませんでした。(gotNextTickTrigger の fire 順に救われた形)

[wait-end]: https://github.com/akashic-games/game-driver/blob/main/src/GameLoop.ts#L734
[set-consumed]: https://github.com/akashic-games/game-driver/blob/main/src/GameLoop.ts#L738-L739