### PR TITLE
fix: avoid audio playback rate changes for small age-zero-skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.7.1
+* 実行開始直後のごく短い早送りに限り、音声再生速度を変更しないように
+
 ## 2.7.0
 * @akashic/akashic-engine@3.4.0 に追従
 * @akashic/game-configuration@1.3.0 に追従

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,7 +21,7 @@ module.exports = {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ["**/*.{js}", "!**/node_modules/**"],
+  collectCoverageFrom: ["lib/**/*.js", "!**/node_modules/**"],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: "coverage",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/spec/src/TickBufferSpec.ts
+++ b/spec/src/TickBufferSpec.ts
@@ -651,4 +651,131 @@ describe("TickBuffer", function() {
 		amflow.requestsGetTicks[0].respond(null, [[4], [5]]);
 		expect(noTickCount).toBe(3);
 	});
+
+	it("can check whether or not the latest tick is near - no events", function () {
+		const amflow = new MockAmflow();
+		const tb = new TickBuffer({
+			amflow: amflow,
+			executionMode: ExecutionMode.Passive,
+			prefetchThreshold: 3,
+			sizeRequestOnce: 2
+		});
+
+		const frameTime = 60 / 1000;
+		expect(tb._calcKnownLatestTickTimeDelta(1, 0, frameTime)).toBe(0);
+
+		tb.requestTicks(0, 3);
+		amflow.requestsGetTicks[0].respond(null, [[0], [1], [2]]);
+		expect(tb._calcKnownLatestTickTimeDelta(2 * frameTime, 0, frameTime)).toBe(2 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(3 * frameTime, 0, frameTime)).toBe(3 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(4 * frameTime, 0, frameTime)).toBe(3 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBe(3 * frameTime);
+
+		tb.requestTicks(4, 1);
+		amflow.requestsGetTicks[0].respond(null, [[4]]);
+		// age 3 がない (間隙がある) があるので Infinity
+		expect(tb._calcKnownLatestTickTimeDelta(3 * frameTime, 0, frameTime)).toBe(Infinity);
+
+		tb.requestTicks(3, 3);
+		amflow.requestsGetTicks[0].respond(null, [[3], [4], [5]]);
+		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBe(5 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(6 * frameTime, 0, frameTime)).toBe(6 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBe(6 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBe(6 * frameTime);
+	});
+
+	it("can check whether or not the latest tick is near - no timestamp", function () {
+		const amflow = new MockAmflow();
+		const tb = new TickBuffer({
+			amflow: amflow,
+			executionMode: ExecutionMode.Passive,
+			prefetchThreshold: 3,
+			sizeRequestOnce: 2
+		});
+
+		const frameTime = 60 / 1000;
+		const nonTimestampEvent = [pl.EventCode.Message, 0, "dummy", {}] as pl.Event;
+
+		tb.requestTicks(0, 3);
+		amflow.requestsGetTicks[0].respond(null, [[0], [1, [nonTimestampEvent]], [2]]);
+		expect(tb._calcKnownLatestTickTimeDelta(2 * frameTime, 0, frameTime)).toBe(2 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(3 * frameTime, 0, frameTime)).toBe(3 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(4 * frameTime, 0, frameTime)).toBe(3 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBe(3 * frameTime);
+
+		tb.requestTicks(3, 3);
+		amflow.requestsGetTicks[0].respond(null, [[3], [4], [5]]);
+		expect(tb._calcKnownLatestTickTimeDelta(4 * frameTime, 0, frameTime)).toBe(4 * frameTime); // 途中 (age 1) でtimeThresholdを超えるケース
+		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBe(5 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(6 * frameTime, 0, frameTime)).toBe(6 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBe(6 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBe(6 * frameTime);
+
+		tb.requestTicks(6, 3);
+		amflow.requestsGetTicks[0].respond(null, [[6, [nonTimestampEvent]], [7], [8]]);
+		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBe(7 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBe(8 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(9 * frameTime, 0, frameTime)).toBe(9 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(10 * frameTime, 0, frameTime)).toBe(9 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(11 * frameTime, 0, frameTime)).toBe(9 * frameTime);
+
+		expect(tb.consume()).toBe(0); // イベントがある age 1 が先頭になるケースを確認するためにage 0を消化
+		expect(tb._calcKnownLatestTickTimeDelta(2 * frameTime, 0, frameTime)).toBe(2 * frameTime); // 途中 (age 6) で超えるケース
+		expect(tb._calcKnownLatestTickTimeDelta(6 * frameTime, 0, frameTime)).toBe(6 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBe(7 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBe(8 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(9 * frameTime, 0, frameTime)).toBe(8 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(10 * frameTime, 0, frameTime)).toBe(8 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(11 * frameTime, 0, frameTime)).toBe(8 * frameTime);
+	});
+
+	it("can check whether or not the latest tick is near - with timestamp", function () {
+		const amflow = new MockAmflow();
+		const tb = new TickBuffer({
+			amflow: amflow,
+			executionMode: ExecutionMode.Passive,
+			prefetchThreshold: 3,
+			sizeRequestOnce: 2
+		});
+
+		const frameTime = 10;
+		const nonTimestampEvent = [pl.EventCode.Message, 0, "dummy", {}] as pl.Event;
+
+		const baseTime = Date.parse("2022-04-01T08:00:00.000");
+		function makeTimestampEvent(t: number): pl.Event {
+			return [pl.EventCode.Timestamp, 0, "dummy", baseTime + t];
+		}
+
+		tb.requestTicks(0, 3);
+		amflow.requestsGetTicks[0].respond(null, [[0], [1, [nonTimestampEvent, makeTimestampEvent(500)]], [2]]);
+		expect(tb._calcKnownLatestTickTimeDelta(500, baseTime, frameTime)).toBe(500);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 1 * frameTime, baseTime, frameTime)).toBe(500 + 1 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 2 * frameTime, baseTime, frameTime)).toBe(500 + 2 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 3 * frameTime, baseTime, frameTime)).toBe(500 + 2 * frameTime);
+
+		let accessCount = 0;
+		const trap = [pl.EventCode.Message, 0, "dummy", {}] as pl.Event;
+		Object.defineProperty(trap, 0, {
+			get: () => {
+				++accessCount;
+				return pl.EventCode.Message;
+			}
+		});
+
+		tb.requestTicks(3, 3);
+		amflow.requestsGetTicks[0].respond(null, [[3], [4], [5, [trap]]]);
+		expect(accessCount).toBe(0);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 3 * frameTime, baseTime, frameTime)).toBe(500 + 3 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 4 * frameTime, baseTime, frameTime)).toBe(500 + 4 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 5 * frameTime, baseTime, frameTime)).toBe(500 + 5 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 6 * frameTime, baseTime, frameTime)).toBe(500 + 5 * frameTime);
+		expect(accessCount).toBe(4);
+
+		tb.requestTicks(6, 2);
+		amflow.requestsGetTicks[0].respond(null, [[6], [7, [trap]], [8, [makeTimestampEvent(1000)]]]);
+		expect(tb._calcKnownLatestTickTimeDelta(1000 + 0 * frameTime, baseTime, frameTime)).toBe(1000 + 0 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(1000 + 1 * frameTime, baseTime, frameTime)).toBe(1000 + 1 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(1000 + 2 * frameTime, baseTime, frameTime)).toBe(1000 + 1 * frameTime);
+		expect(accessCount).toBe(4); // 後続 tick に timestamp がある場合、それ以前のイベントが参照されることはない
+	});
 });

--- a/spec/src/TickBufferSpec.ts
+++ b/spec/src/TickBufferSpec.ts
@@ -652,7 +652,7 @@ describe("TickBuffer", function() {
 		expect(noTickCount).toBe(3);
 	});
 
-	it("can check whether or not the latest tick is near - no events", function () {
+	it("can calculate duration to consume the latest tick - no events", function () {
 		const amflow = new MockAmflow();
 		const tb = new TickBuffer({
 			amflow: amflow,
@@ -661,30 +661,30 @@ describe("TickBuffer", function() {
 			sizeRequestOnce: 2
 		});
 
-		const frameTime = 60 / 1000;
+		const frameTime = 1000 / 60;
 		expect(tb._calcKnownLatestTickTimeDelta(1, 0, frameTime)).toBe(0);
 
 		tb.requestTicks(0, 3);
 		amflow.requestsGetTicks[0].respond(null, [[0], [1], [2]]);
-		expect(tb._calcKnownLatestTickTimeDelta(2 * frameTime, 0, frameTime)).toBe(2 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(3 * frameTime, 0, frameTime)).toBe(3 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(4 * frameTime, 0, frameTime)).toBe(3 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBe(3 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(2 * frameTime, 0, frameTime)).toBeCloseTo(2 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(3 * frameTime, 0, frameTime)).toBeCloseTo(3 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(4 * frameTime, 0, frameTime)).toBeCloseTo(3 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBeCloseTo(3 * frameTime, 3);
 
 		tb.requestTicks(4, 1);
 		amflow.requestsGetTicks[0].respond(null, [[4]]);
 		// age 3 がない (間隙がある) があるので Infinity
-		expect(tb._calcKnownLatestTickTimeDelta(3 * frameTime, 0, frameTime)).toBe(Infinity);
+		expect(tb._calcKnownLatestTickTimeDelta(3 * frameTime, 0, frameTime)).toBeCloseTo(Infinity);
 
 		tb.requestTicks(3, 3);
 		amflow.requestsGetTicks[0].respond(null, [[3], [4], [5]]);
-		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBe(5 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(6 * frameTime, 0, frameTime)).toBe(6 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBe(6 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBe(6 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBeCloseTo(5 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(6 * frameTime, 0, frameTime)).toBeCloseTo(6 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBeCloseTo(6 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBeCloseTo(6 * frameTime, 3);
 	});
 
-	it("can check whether or not the latest tick is near - no timestamp", function () {
+	it("can calculate duration to consume the latest tick - no timestamp", function () {
 		const amflow = new MockAmflow();
 		const tb = new TickBuffer({
 			amflow: amflow,
@@ -693,43 +693,43 @@ describe("TickBuffer", function() {
 			sizeRequestOnce: 2
 		});
 
-		const frameTime = 60 / 1000;
+		const frameTime = 1000 / 30;
 		const nonTimestampEvent = [pl.EventCode.Message, 0, "dummy", {}] as pl.Event;
 
 		tb.requestTicks(0, 3);
 		amflow.requestsGetTicks[0].respond(null, [[0], [1, [nonTimestampEvent]], [2]]);
-		expect(tb._calcKnownLatestTickTimeDelta(2 * frameTime, 0, frameTime)).toBe(2 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(3 * frameTime, 0, frameTime)).toBe(3 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(4 * frameTime, 0, frameTime)).toBe(3 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBe(3 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(2 * frameTime, 0, frameTime)).toBeCloseTo(2 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(3 * frameTime, 0, frameTime)).toBeCloseTo(3 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(4 * frameTime, 0, frameTime)).toBeCloseTo(3 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBeCloseTo(3 * frameTime, 3);
 
 		tb.requestTicks(3, 3);
 		amflow.requestsGetTicks[0].respond(null, [[3], [4], [5]]);
-		expect(tb._calcKnownLatestTickTimeDelta(4 * frameTime, 0, frameTime)).toBe(4 * frameTime); // 途中 (age 1) でtimeThresholdを超えるケース
-		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBe(5 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(6 * frameTime, 0, frameTime)).toBe(6 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBe(6 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBe(6 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(4 * frameTime, 0, frameTime)).toBeCloseTo(4 * frameTime, 3); // 途中 (age 1) でtimeThresholdを超えるケース
+		expect(tb._calcKnownLatestTickTimeDelta(5 * frameTime, 0, frameTime)).toBeCloseTo(5 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(6 * frameTime, 0, frameTime)).toBeCloseTo(6 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBeCloseTo(6 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBeCloseTo(6 * frameTime, 3);
 
 		tb.requestTicks(6, 3);
 		amflow.requestsGetTicks[0].respond(null, [[6, [nonTimestampEvent]], [7], [8]]);
-		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBe(7 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBe(8 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(9 * frameTime, 0, frameTime)).toBe(9 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(10 * frameTime, 0, frameTime)).toBe(9 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(11 * frameTime, 0, frameTime)).toBe(9 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBeCloseTo(7 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBeCloseTo(8 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(9 * frameTime, 0, frameTime)).toBeCloseTo(9 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(10 * frameTime, 0, frameTime)).toBeCloseTo(9 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(11 * frameTime, 0, frameTime)).toBeCloseTo(9 * frameTime, 3);
 
 		expect(tb.consume()).toBe(0); // イベントがある age 1 が先頭になるケースを確認するためにage 0を消化
-		expect(tb._calcKnownLatestTickTimeDelta(2 * frameTime, 0, frameTime)).toBe(2 * frameTime); // 途中 (age 6) で超えるケース
-		expect(tb._calcKnownLatestTickTimeDelta(6 * frameTime, 0, frameTime)).toBe(6 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBe(7 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBe(8 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(9 * frameTime, 0, frameTime)).toBe(8 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(10 * frameTime, 0, frameTime)).toBe(8 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(11 * frameTime, 0, frameTime)).toBe(8 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(2 * frameTime, 0, frameTime)).toBeCloseTo(2 * frameTime, 3); // 途中 (age 6) で超えるケース
+		expect(tb._calcKnownLatestTickTimeDelta(6 * frameTime, 0, frameTime)).toBeCloseTo(6 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(7 * frameTime, 0, frameTime)).toBeCloseTo(7 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(8 * frameTime, 0, frameTime)).toBeCloseTo(8 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(9 * frameTime, 0, frameTime)).toBeCloseTo(8 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(10 * frameTime, 0, frameTime)).toBeCloseTo(8 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(11 * frameTime, 0, frameTime)).toBeCloseTo(8 * frameTime, 3);
 	});
 
-	it("can check whether or not the latest tick is near - with timestamp", function () {
+	it("can calculate duration to consume the latest tick - with timestamp", function () {
 		const amflow = new MockAmflow();
 		const tb = new TickBuffer({
 			amflow: amflow,
@@ -738,7 +738,7 @@ describe("TickBuffer", function() {
 			sizeRequestOnce: 2
 		});
 
-		const frameTime = 10;
+		const frameTime = 1000 / 60;
 		const nonTimestampEvent = [pl.EventCode.Message, 0, "dummy", {}] as pl.Event;
 
 		const baseTime = Date.parse("2022-04-01T08:00:00.000");
@@ -748,10 +748,10 @@ describe("TickBuffer", function() {
 
 		tb.requestTicks(0, 3);
 		amflow.requestsGetTicks[0].respond(null, [[0], [1, [nonTimestampEvent, makeTimestampEvent(500)]], [2]]);
-		expect(tb._calcKnownLatestTickTimeDelta(500, baseTime, frameTime)).toBe(500);
-		expect(tb._calcKnownLatestTickTimeDelta(500 + 1 * frameTime, baseTime, frameTime)).toBe(500 + 1 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(500 + 2 * frameTime, baseTime, frameTime)).toBe(500 + 2 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(500 + 3 * frameTime, baseTime, frameTime)).toBe(500 + 2 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(500, baseTime, frameTime)).toBeCloseTo(500, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 1 * frameTime, baseTime, frameTime)).toBeCloseTo(500 + 1 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 2 * frameTime, baseTime, frameTime)).toBeCloseTo(500 + 2 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 3 * frameTime, baseTime, frameTime)).toBeCloseTo(500 + 2 * frameTime, 3);
 
 		let accessCount = 0;
 		const trap = [pl.EventCode.Message, 0, "dummy", {}] as pl.Event;
@@ -765,17 +765,17 @@ describe("TickBuffer", function() {
 		tb.requestTicks(3, 3);
 		amflow.requestsGetTicks[0].respond(null, [[3], [4], [5, [trap]]]);
 		expect(accessCount).toBe(0);
-		expect(tb._calcKnownLatestTickTimeDelta(500 + 3 * frameTime, baseTime, frameTime)).toBe(500 + 3 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(500 + 4 * frameTime, baseTime, frameTime)).toBe(500 + 4 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(500 + 5 * frameTime, baseTime, frameTime)).toBe(500 + 5 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(500 + 6 * frameTime, baseTime, frameTime)).toBe(500 + 5 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 3 * frameTime, baseTime, frameTime)).toBeCloseTo(500 + 3 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 4 * frameTime, baseTime, frameTime)).toBeCloseTo(500 + 4 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 5 * frameTime, baseTime, frameTime)).toBeCloseTo(500 + 5 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(500 + 6 * frameTime, baseTime, frameTime)).toBeCloseTo(500 + 5 * frameTime, 3);
 		expect(accessCount).toBe(4);
 
 		tb.requestTicks(6, 2);
 		amflow.requestsGetTicks[0].respond(null, [[6], [7, [trap]], [8, [makeTimestampEvent(1000)]]]);
-		expect(tb._calcKnownLatestTickTimeDelta(1000 + 0 * frameTime, baseTime, frameTime)).toBe(1000 + 0 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(1000 + 1 * frameTime, baseTime, frameTime)).toBe(1000 + 1 * frameTime);
-		expect(tb._calcKnownLatestTickTimeDelta(1000 + 2 * frameTime, baseTime, frameTime)).toBe(1000 + 1 * frameTime);
+		expect(tb._calcKnownLatestTickTimeDelta(1000 + 0 * frameTime, baseTime, frameTime)).toBeCloseTo(1000 + 0 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(1000 + 1 * frameTime, baseTime, frameTime)).toBeCloseTo(1000 + 1 * frameTime, 3);
+		expect(tb._calcKnownLatestTickTimeDelta(1000 + 2 * frameTime, baseTime, frameTime)).toBeCloseTo(1000 + 1 * frameTime, 3);
 		expect(accessCount).toBe(4); // 後続 tick に timestamp がある場合、それ以前のイベントが参照されることはない
 	});
 });

--- a/spec/src/TickBufferSpec.ts
+++ b/spec/src/TickBufferSpec.ts
@@ -763,7 +763,7 @@ describe("TickBuffer", function() {
 		});
 
 		tb.requestTicks(3, 3);
-		amflow.requestsGetTicks[0].respond(null, [[3], [4], [5, [trap]]]);
+		amflow.requestsGetTicks[0].respond(null, [[3], [4, null, []], [5, [trap]]]);
 		expect(accessCount).toBe(0);
 		expect(tb._calcKnownLatestTickTimeDelta(500 + 3 * frameTime, baseTime, frameTime)).toBeCloseTo(500 + 3 * frameTime, 3);
 		expect(tb._calcKnownLatestTickTimeDelta(500 + 4 * frameTime, baseTime, frameTime)).toBeCloseTo(500 + 4 * frameTime, 3);
@@ -771,7 +771,7 @@ describe("TickBuffer", function() {
 		expect(tb._calcKnownLatestTickTimeDelta(500 + 6 * frameTime, baseTime, frameTime)).toBeCloseTo(500 + 5 * frameTime, 3);
 		expect(accessCount).toBe(4);
 
-		tb.requestTicks(6, 2);
+		tb.requestTicks(6, 3);
 		amflow.requestsGetTicks[0].respond(null, [[6], [7, [trap]], [8, [makeTimestampEvent(1000)]]]);
 		expect(tb._calcKnownLatestTickTimeDelta(1000 + 0 * frameTime, baseTime, frameTime)).toBeCloseTo(1000 + 0 * frameTime, 3);
 		expect(tb._calcKnownLatestTickTimeDelta(1000 + 1 * frameTime, baseTime, frameTime)).toBeCloseTo(1000 + 1 * frameTime, 3);

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -324,6 +324,8 @@ export class GameLoop {
 	 * 少々の遅れはこのクラスが暗黙に早回しして吸収する。
 	 * 早送り状態は、暗黙の早回しでは吸収しきれない規模の早回しの開始時に通知される。
 	 * 具体的な値との関連は `skipThreshold` など `LoopConfiguration` のメンバを参照のこと。
+	 *
+	 * @param isNear 真の場合、ゲームの再生速度設定を変えない (実質 "効果音をミュートしない")。ゲームへのスキッピング通知は行うことに注意。
 	 */
 	_startSkipping(isNear: boolean): void {
 		this._skipping = true;

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -663,7 +663,7 @@ export class GameLoop {
 			// ここでは常に (ageGap > 0) であることに注意。(0の時にskipに入ってもすぐ戻ってしまう)
 			const isTargetNear =
 				(currentAge === 0) && // 余計な関数呼び出しを避けるためにチェック
-				this._tickBuffer.isKnownLatestTickTimeNear(this._skipThreshold, this._currentTime, this._frameTime);
+				this._tickBuffer.isKnownLatestTickTimeNear(this._skipThresholdTime, this._currentTime, this._frameTime);
 			this._startSkipping(isTargetNear);
 		}
 

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -250,6 +250,17 @@ export class TickBuffer {
 		return this.readNextTickTime();
 	}
 
+	/**
+	 * 既知の最新tickが「近い」かどうか判定する。
+	 * ここで「近い」とは、既知最新 tick の消化までに必要なゲーム内時間が timeThreshold より短いことである。
+	 * tick をトラバースするので最悪の場合の実行時間は timeThreshold に比例する点に注意。
+	 */
+	isKnownLatestTickTimeNear(timeThreshold: number, baseTime: number, frameTime: number): boolean {
+		// TODO コード整理して baseTime と frameTime の引数をなくす。
+		// 両者は GameLoop#_frameTime, _currentTime にそれぞれ対応している。このクラスがそれらを管理する方が自然。
+		return this._calcKnownLatestTickTimeDelta(timeThreshold, baseTime, frameTime) >= timeThreshold;
+	}
+
 	requestTicks(from: number = this.currentAge, len: number = this._sizeRequestOnce): void {
 		if (this._skipping) {
 			this.requestNonIgnorableTicks(from, len);
@@ -484,6 +495,55 @@ export class TickBuffer {
 				break;
 		}
 		range.ticks = range.ticks.slice(i);
+	}
+
+	/**
+	 * 既知最新 Tick の時刻までの所要時間を求める。
+	 * ただし timeThreshold を超える場合、処理を打ち切って timeThreshold を返す。
+	 * また間隙がある (途中に欠けた Tick がある) 場合、Infinity を返す。
+	 *
+	 * _tickRanges をトラバースするので、最悪の場合の実行時間は timeThreshold に比例する。
+	 */
+	_calcKnownLatestTickTimeDelta(timeThreshold: number, baseTime: number, frameTime: number): number {
+		const tickRanges = this._tickRanges;
+		if (tickRanges.length === 0)
+			return 0;
+
+		let timeDelta = 0;
+		let lastRangeStart = tickRanges[tickRanges.length - 1].end;
+		let lastAgeWithEvents = lastRangeStart;
+		for (let i = tickRanges.length - 1; i >= 0; --i) {
+			const range = tickRanges[i];
+			if (range.end !== lastRangeStart) // 既知tickに間隙がある場合
+				return Infinity;
+			lastRangeStart = range.start;
+
+			const ticksWithEvents = range.ticks;
+			for (let j = ticksWithEvents.length - 1; j >= 0; --j) {
+				const tick = ticksWithEvents[j];
+				const pevs = tick[EventIndex.Tick.Events];
+				if (!pevs) // ticksWithEvents は「ストレージまたはイベントを持つtick」なのでイベントはない場合もある
+					continue;
+
+				// この tick までの時間を加算
+				const age = tick[EventIndex.Tick.Age];
+				timeDelta += (lastAgeWithEvents - age) * frameTime;
+				if (timeDelta > timeThreshold) // timestamp なしの tick だけで timeThreshold 分の時間を超過した
+					return timeThreshold;
+				lastAgeWithEvents = age;
+
+				// timestamp が見つかれば時間が確定する
+				for (let k = 0; k < pevs.length; ++k) {
+					if (pevs[k][EventIndex.General.Code] === pl.EventCode.Timestamp) {
+						const timestamp = pevs[k][EventIndex.Timestamp.Timestamp];
+						const latestTickTime = timestamp + timeDelta;
+						return Math.min(latestTickTime - baseTime, timeThreshold);
+					}
+				}
+			}
+		}
+		timeDelta += (lastAgeWithEvents - tickRanges[0].start) * frameTime;
+		return Math.min(timeDelta, timeThreshold);
 	}
 
 	private _createTickRangeFromTick(tick: pl.Tick): TickRange {

--- a/src/TickBuffer.ts
+++ b/src/TickBuffer.ts
@@ -258,7 +258,7 @@ export class TickBuffer {
 	isKnownLatestTickTimeNear(timeThreshold: number, baseTime: number, frameTime: number): boolean {
 		// TODO コード整理して baseTime と frameTime の引数をなくす。
 		// 両者は GameLoop#_frameTime, _currentTime にそれぞれ対応している。このクラスがそれらを管理する方が自然。
-		return this._calcKnownLatestTickTimeDelta(timeThreshold, baseTime, frameTime) >= timeThreshold;
+		return this._calcKnownLatestTickTimeDelta(timeThreshold, baseTime, frameTime) < timeThreshold;
 	}
 
 	requestTicks(from: number = this.currentAge, len: number = this._sizeRequestOnce): void {
@@ -536,8 +536,8 @@ export class TickBuffer {
 				for (let k = 0; k < pevs.length; ++k) {
 					if (pevs[k][EventIndex.General.Code] === pl.EventCode.Timestamp) {
 						const timestamp = pevs[k][EventIndex.Timestamp.Timestamp];
-						const latestTickTime = timestamp + timeDelta;
-						return Math.min(latestTickTime - baseTime, timeThreshold);
+						const duration = (timestamp - baseTime) + timeDelta; // 計算順に注意。先に時刻を減算して値を小さくする(小数部の誤差を軽減する)
+						return Math.min(duration, timeThreshold);
 					}
 				}
 			}


### PR DESCRIPTION
### 経緯と変更内容

掲題どおり。ゲーム実行開始直後のスキップ時、それがごく短い (通常であればスキップ状態に入らないほど短い) 早回しである場合、音声の再生速度変更 (＝SEのミュート) をしないようにします。

歴史的経緯から、ゲームの実行開始直後には必ず一度スキップ状態になります。スキップ状態では SE ("sound" のオーディオアセット) はミュートされます。passive インスタンスは開始時に active インスタンスから十フレーム程度遅れていることが多く、そのため開始直後に再生された SE がミュートされてしまうことがありました。この PR はこの問題を修正します。

### 補足
#### スキップと早回し

これらは Akashic 用語です。ゲームの最新状態に追いつく必要がある時、game-driver は 1 フレーム時間の間に複数 tick を消化します。これを "早回し" といいます 。早回しで消化する tick が閾値より多い (遅れが大きい) 場合、game-driver はこれをコンテンツに通知します。これを "スキップする" (または "早送りする") といいます。スキップ開始通知からスキップ終了通知までの間を、スキップ状態と呼びます。言い換えるとスキップは「コンテンツに通知されるほど長い早回し」です。

ただし上述のとおり歴史的経緯から、ゲームの実行開始時には、遅れの程度にかかわらず必ず一度スキップします。

#### SE はミュートすべきか

これは程度問題です。マルチプレイに参加する時、ゲームプレイの最新状態に追いつくために早回しは不可避であり、この時 SE はミュートされないと不快です (大量の SE が短時間に再生される) 。他方ですぐに追いつく、極論気づかれない程度の早回しでは、 ミュートされる方が不自然です。その境界は機械的に定まるものではありません。

ただ上述のとおり、ゲームの実行開始時には、遅れの程度にかかわらず必ず一度スキップ状態になります。この特例的な動作に鑑み、この PR では「通常ならスキップしない程度の遅れ」の場合に、SE のミュートを行わないようにします。

#### 破壊的変更か

いいえ。破壊的変更ではありません。スキップに伴うミュートは、 [`AudioSystem#_suppressed` という独立した変数](https://github.com/akashic-games/akashic-engine/blob/main/src/AudioSystem.ts#L48) で管理されていて、コンテンツやプラットフォームからの音量指定とは独立です。またこの変数は非公開扱いです。

### 動作確認

ユニットテストの他、akashic serve に組み込んで「1 tick 目に SE を再生するコンテンツ」でリアルタイム・リプレイともに動作を確認しています。
