### PR TITLE
fix: pass game arguments even with snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.12.1
+* スナップショットからの復元時、エントリポイントの引数 `args` が渡されていなかった問題を修正
+
 ## 2.12.0
 * @akashic/akashic-engine@3.10.0 に追従
 * @akashic/game-configuration@1.9.0 に追従

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -148,7 +148,7 @@ export class Game extends g.Game {
 			this._loadAndStart({ args: this._gameArgs, globalArgs: this._globalGameArgs });
 		} else {
 			this._reset({ age: snapshot.frame, nextEntityId: data.nextEntityId, randGenSer: data.randGenSer });
-			this._loadAndStart({ snapshot: data.gameSnapshot });
+			this._loadAndStart({ args: this._gameArgs, snapshot: data.gameSnapshot });
 		}
 	}
 

--- a/src/__tests__/Game.spec.ts
+++ b/src/__tests__/Game.spec.ts
@@ -176,4 +176,27 @@ describe("Game", function() {
 			}
 		});
 	});
+
+	it("passes gameArgs - without snapshot", function (done: any) {
+		const game = prepareGame({ title: FixtureGame.SimpleGame, playerId: "dummyPlayerId", gameArgs: { foo: 1 } });
+		game.loadAndDo(() => {
+			expect(game.vars.args.foo).toBe(1);
+			done();
+		}, {
+			frame: 0,
+			data: { seed: 0 }
+		});
+	});
+
+	it("passes gameArgs - with snapshot", function (done: any) {
+		const game = prepareGame({ title: FixtureGame.SimpleGame, playerId: "dummyPlayerId", gameArgs: { foo: 2 } });
+		const randGenSer = (new g.XorshiftRandomGenerator(0)).serialize();
+		game.loadAndDo(() => {
+			expect(game.vars.args.foo).toBe(2);
+			done();
+		}, {
+			frame: 10,
+			data: { nextEntityId: 3, randGenSer, gameSnapshot: { bar: 1 } }
+		});
+	});
 });

--- a/src/__tests__/fixtures/simple_game/script/main.js
+++ b/src/__tests__/fixtures/simple_game/script/main.js
@@ -1,5 +1,7 @@
 var game = g.game;
-module.exports = function() {
+module.exports = function(param) {
+	g.game.vars.args = param.args;
+
 	var scene = new g.Scene({ game: game });
 	scene.onLoad.add(function() {
 		var r1 = new g.FilledRect({

--- a/src/__tests__/helpers/MockGame.ts
+++ b/src/__tests__/helpers/MockGame.ts
@@ -21,9 +21,8 @@ export class MockGame extends Game {
 		this.onResetTrigger.fire();
 	}
 
-	loadAndDo(func: () => void): void {
+	loadAndDo(func: () => void, snapshot?: any): void {
 		this.autoTickForSceneChange = true;
-		this._reset();
 		this._sceneChanged.handle((scene: g.Scene) => {
 			if (scene.local === "non-local") {
 				if (scene._loadingState === "loaded-fired") {
@@ -38,7 +37,12 @@ export class MockGame extends Game {
 				return true;
 			}
 		});
-		this._loadAndStart();
+		if (!snapshot) {
+			this._reset();
+			this._loadAndStart();
+		} else {
+			this._restartWithSnapshot(snapshot);
+		}
 	}
 
 	_pushPostTickTask(fun: () => void, owner: any): void {

--- a/src/__tests__/helpers/prepareGame.ts
+++ b/src/__tests__/helpers/prepareGame.ts
@@ -26,6 +26,7 @@ export interface PrepareGameParameterObject {
 	playerId?: string;
 	player?: g.Player;
 	scriptLoadDelay?: number;
+	gameArgs?: any;
 }
 
 export function prepareGame(param: PrepareGameParameterObject): MockGame {
@@ -51,7 +52,8 @@ export function prepareGame(param: PrepareGameParameterObject): MockGame {
 		resourceFactory: new mockrf.ResourceFactory({ scriptLoadDelay: param.scriptLoadDelay }),
 		assetBase: assetBase,
 		selfId: param.playerId,
-		player: param.player ? param.player : { id: param.playerId }
+		player: param.player ? param.player : { id: param.playerId },
+		gameArgs: param.gameArgs
 	});
 	return game;
 }


### PR DESCRIPTION
掲題どおり。

スナップショットからの復元時、起動引数が渡されていませんでした。起動引数は実行環境に依存する値なので、「スナップショットからの復元時にそれを参照していいかどうか」はエンジン本体には決められないものでした。通常起動時と同様そのまま引き渡すようにします。
