### PR TITLE
Fix set-output command in Actions

### DIFF
--- a/.github/workflows/reftest.yml
+++ b/.github/workflows/reftest.yml
@@ -30,7 +30,7 @@ jobs:
         id: game_driver
         run: |
           npm ci
-          echo "::set-output name=pack_name::$(npm pack)"
+          echo "pack_name=$(npm pack)" >> $GITHUB_OUTPUT
       - name: Run engine-files reftest
         working-directory: engine-files
         run: |


### PR DESCRIPTION
## 概要

Actions の set-output コマンドが廃止となるため、$GITHUB_OUTPUT を利用するように修正。
