### PR TITLE
fix: rename/avoid a property override to fix duplicated destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 2.17.0
+* ローディングシーン中に `Game#destroy()` するとエラーになる問題を修正
+  * `Game#handlerSet` の型を (オーバーライドしない) `g.GameHandlerSet` に
+  * `Game#rawHandlerSet: GameHandlerSet` を追加
+
 ## 2.16.0
 * @akashic/akashic-engine@3.14.0 に追従
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/game-driver",
-      "version": "2.16.0",
+      "version": "2.17.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-engine": "~3.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.16.0",
+  "version": "2.17.0",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -132,7 +132,7 @@ export class Game extends g.Game {
 		this._isSkipAware = aware;
 	}
 
-	_destroy(): void {
+	override _destroy(): void {
 		this.agePassedTrigger.destroy();
 		this.agePassedTrigger = null!;
 		this.targetTimeReachedTrigger.destroy();

--- a/src/Game.ts
+++ b/src/Game.ts
@@ -51,7 +51,16 @@ export class Game extends g.Game {
 	abortTrigger: g.Trigger<void> = new g.Trigger();
 
 	player: g.Player;
-	handlerSet: GameHandlerSet;
+
+	/**
+	 * ハンドラセット。
+	 *
+	 * 祖先クラスの `g.Game#handlerSet: g.GameHandlerSet` と同じ値を保持する。
+	 * 利用箇所で逐一ダウンキャストが必要になるのを避けるため、
+	 * (g なしの) `GameHandlerSet` である (そのことに意味がある) 点に注意。
+	 */
+	rawHandlerSet: GameHandlerSet;
+
 	_notifyPassedAgeTable: { [age: number]: boolean } = Object.create(null);
 	_notifiesTargetTimeReached: boolean = false;
 	_isSkipAware: boolean = false;
@@ -61,7 +70,7 @@ export class Game extends g.Game {
 	constructor(param: GameParameterObject) {
 		super(param);
 		this.player = param.player;
-		this.handlerSet = param.handlerSet;
+		this.rawHandlerSet = param.handlerSet;
 		this._gameArgs = param.gameArgs;
 		this._globalGameArgs = param.globalGameArgs;
 		this.skippingChangedTrigger.add(this._onSkippingChanged, this);
@@ -133,7 +142,7 @@ export class Game extends g.Game {
 		this.abortTrigger.destroy();
 		this.abortTrigger = null!;
 		this.player = null!;
-		this.handlerSet = null!;
+		this.rawHandlerSet = null!;
 		this._notifyPassedAgeTable = null!;
 		this._gameArgs = null;
 		this._globalGameArgs = null;

--- a/src/GameDriver.ts
+++ b/src/GameDriver.ts
@@ -412,7 +412,7 @@ export class GameDriver {
 				this._playToken = playToken;
 				this._permission = permission;
 				if (this._game) {
-					this._game.handlerSet.isSnapshotSaver = permission.writeTick;
+					this._game.rawHandlerSet.isSnapshotSaver = permission.writeTick;
 				}
 				resolve();
 			});

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -207,9 +207,9 @@ export class GameLoop {
 		this._setLoopRenderMode(loopRenderMode);
 		this._game.setIsSkipAware(conf.skipAwareGame != null ? conf.skipAwareGame : true);
 		this._game.setStorageFunc(this._tickController.storageFunc());
-		this._game.handlerSet.raiseEventTrigger.add(this._onGameRaiseEvent, this);
-		this._game.handlerSet.raiseTickTrigger.add(this._onGameRaiseTick, this);
-		this._game.handlerSet.changeSceneModeTrigger.add(this._handleSceneChange, this);
+		this._game.rawHandlerSet.raiseEventTrigger.add(this._onGameRaiseEvent, this);
+		this._game.rawHandlerSet.raiseTickTrigger.add(this._onGameRaiseTick, this);
+		this._game.rawHandlerSet.changeSceneModeTrigger.add(this._handleSceneChange, this);
 		this._game._onStart.add(this._onGameStarted, this);
 		this._tickBuffer.gotNextTickTrigger.add(this._onGotNextFrameTick, this);
 		this._tickBuffer.gotNoTickTrigger.add(this._onGotNoTick, this);

--- a/src/ProfilerClock.ts
+++ b/src/ProfilerClock.ts
@@ -24,7 +24,7 @@ export class ProfilerClock extends Clock {
 		this._profiler = param.profiler;
 	}
 
-	_onLooperCall(deltaTime: number): number {
+	override _onLooperCall(deltaTime: number): number {
 		const rawDeltaTime = deltaTime;
 
 		if (deltaTime <= 0) {

--- a/src/__tests__/Game.spec.ts
+++ b/src/__tests__/Game.spec.ts
@@ -55,6 +55,17 @@ describe("Game", function() {
 		expect(game.skippingChangedTrigger).toBe(null);
 	});
 
+	it("can be destroyed - after load", function (done: any) {
+		const game = prepareGame({ title: FixtureGame.SimpleGame, playerId: "dummyPlayerId", gameArgs: { foo: 1 } });
+		game.loadAndDo(() => {
+			game._destroy();
+			done();
+		}, {
+			frame: 0,
+			data: { seed: 0 }
+		});
+	});
+
 	it("notifies on _abortGame()", () => {
 		const rf = new mockrf.ResourceFactory();
 		const handlerSet = new GameHandlerSet({ isSnapshotSaver: false });

--- a/src/__tests__/GameLoop.spec.ts
+++ b/src/__tests__/GameLoop.spec.ts
@@ -548,7 +548,7 @@ describe("GameLoop", function () {
 		expect(self._frameTime).toBe(1000 / 30);   // 30 は fps. LocalTickGame の game.json 参照。
 		self.rawTargetTimeReachedTrigger.add(game._onRawTargetTimeReached, game);
 		game._reset({ age: 0, randSeed: 0 });
-		game.handlerSet.setEventFilterFuncs({
+		game.rawHandlerSet.setEventFilterFuncs({
 			addFilter: eventBuffer.addFilter.bind(eventBuffer),
 			removeFilter: eventBuffer.removeFilter.bind(eventBuffer)
 		});
@@ -666,7 +666,7 @@ describe("GameLoop", function () {
 		expect(self._frameTime).toBe(1000 / 30);   // 30 は fps. LocalTickGame の game.json 参照。
 		self.rawTargetTimeReachedTrigger.add(game._onRawTargetTimeReached, game);
 		game._reset({ age: 0, randSeed: 0 });
-		game.handlerSet.setEventFilterFuncs({
+		game.rawHandlerSet.setEventFilterFuncs({
 			addFilter: eventBuffer.addFilter.bind(eventBuffer),
 			removeFilter: eventBuffer.removeFilter.bind(eventBuffer)
 		});
@@ -758,7 +758,7 @@ describe("GameLoop", function () {
 
 		self.rawTargetTimeReachedTrigger.add(game._onRawTargetTimeReached, game);
 		game._reset({ age: 0, randSeed: 42 });
-		game.handlerSet.setEventFilterFuncs({
+		game.rawHandlerSet.setEventFilterFuncs({
 			addFilter: eventBuffer.addFilter.bind(eventBuffer),
 			removeFilter: eventBuffer.removeFilter.bind(eventBuffer)
 		});
@@ -819,7 +819,7 @@ describe("GameLoop", function () {
 			looper.fun(self._frameTime);
 		}, 1);
 
-		game.handlerSet.setEventFilterFuncs({
+		game.rawHandlerSet.setEventFilterFuncs({
 			addFilter: (_filter: g.EventFilter) => null,
 			removeFilter: (_filter?: g.EventFilter) => null
 		});
@@ -890,7 +890,7 @@ describe("GameLoop", function () {
 			looper.fun(self._frameTime);
 		}, 1);
 
-		game.handlerSet.setEventFilterFuncs({
+		game.rawHandlerSet.setEventFilterFuncs({
 			addFilter: (_filter: g.EventFilter) => null,
 			removeFilter: (_filter?: g.EventFilter) => null
 		});
@@ -1029,7 +1029,7 @@ describe("GameLoop", function () {
 		}, 1);
 
 		self.rawTargetTimeReachedTrigger.add(game._onRawTargetTimeReached, game);
-		game.handlerSet.setEventFilterFuncs({
+		game.rawHandlerSet.setEventFilterFuncs({
 			addFilter: eventBuffer.addFilter.bind(eventBuffer),
 			removeFilter: eventBuffer.removeFilter.bind(eventBuffer)
 		});
@@ -1097,7 +1097,7 @@ describe("GameLoop", function () {
 		}, 1);
 
 		self.rawTargetTimeReachedTrigger.add(game._onRawTargetTimeReached, game);
-		game.handlerSet.setEventFilterFuncs({
+		game.rawHandlerSet.setEventFilterFuncs({
 			addFilter: eventBuffer.addFilter.bind(eventBuffer),
 			removeFilter: eventBuffer.removeFilter.bind(eventBuffer)
 		});

--- a/src/__tests__/helpers/MockGame.ts
+++ b/src/__tests__/helpers/MockGame.ts
@@ -12,7 +12,7 @@ export class MockGame extends Game {
 		this.autoTickForSceneChange = false;
 	}
 
-	_reset(param?: g.GameResetParameterObject): void {
+	override _reset(param?: g.GameResetParameterObject): void {
 		super._reset(param);
 		if (!this.onResetTrigger) {
 			// _reset() は g.Game のコンストラクタから呼ばれ、 MockGameのコンストラクタで初期化するのでは間に合わないのでここで初期化
@@ -45,7 +45,7 @@ export class MockGame extends Game {
 		}
 	}
 
-	_pushPostTickTask(fun: () => void, owner: any): void {
+	override _pushPostTickTask(fun: () => void, owner: any): void {
 		super._pushPostTickTask(fun, owner);
 		if (this.autoTickForSceneChange) {
 			setTimeout(() => {

--- a/src/__tests__/helpers/MockResourceFactory.ts
+++ b/src/__tests__/helpers/MockResourceFactory.ts
@@ -334,7 +334,7 @@ export class AudioPlayer extends pci.AudioPlayer {
 		this.canHandleStoppedValue = true;
 	}
 
-	canHandleStopped(): boolean {
+	override canHandleStopped(): boolean {
 		return this.canHandleStoppedValue;
 	}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES5",
     "lib": ["es5"],
     "declaration": true,
-    "noImplicitAny": true,
+    "noImplicitOverride": true,
     "strict": true,
     "module": "commonjs",
     "outDir": "./lib"


### PR DESCRIPTION
掲題どおり。 `Game#handlerSet` を `Game#rawHandlerSet` に改名し、祖先クラス `g.Game#handlerSet` のオーバーライドをしないように変更します。

### 問題

main 最新の game-driver を akashic serve に組み込むと、 「新規プレイ」ボタンを押すたびに次のようなエラーが出ます。

```
engineFilesV3_7_3_Canvas.js:4140 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'changeSceneMode')
    at Game._handleSceneChanged (engineFilesV3_7_3_Canvas.js:4140:25)
    at Trigger.fire (engineFilesV3_7_3_Canvas.js:17889:36)
    at Game._doPopScene (engineFilesV3_7_3_Canvas.js:4280:33)
    at Game._flushPostTickTasks (engineFilesV3_7_3_Canvas.js:4188:30)
    at Game._destroy (engineFilesV3_7_3_Canvas.js:3962:22)
    at Game._destroy (engineFilesV3_7_3_Canvas.js:11050:35)
    (snip)
```

確認するとこの例外は以前から throw されていました。しかし es6-promise が握りつぶしてたらしく (詳細未確認)、 #199 以降に露出するようになったようです。

### 原因と観察

(以下、`Game` と `g.Game` が別の型であることに注意してください。 `Game` は game-driver が定義しているクラスで、 `extends g.Game` です)

この問題の直接の原因は、(派生クラスの) `Game#destroy()` が (祖先クラスの) `g.Game#handlerSet` をクリアしていることです。クリアしてから `super.destroy()` を呼ぶため、その中で `g.Game#handlerSet` を参照した時にエラーになります。

祖先クラスのプロパティの破棄は祖先クラスに任せるべきで、 派生側で破棄するのは誤りに思えます。

こうなった原因は、派生クラスが祖先クラスと同名のプロパティ `Game#handlerSet: GameHandlerSet` を定義 (オーバーライド (？)) しているためです。 両者の違いは、祖先クラスでは型が `interface g.GameHandlerSet` であったところ、 派生クラスでは `GameHandlerSet` になっている点です。 `class GameHandlerSet implements g.GameHandlerSet` は game-driver のクラスで、追加のメソッドを参照する都合上、実体の型として扱いたかったためにこうなっています。

派生クラスのプロパティなので一見派生クラスの `destroy()` でクリアすべきに見えますが、実際には祖先クラスと共有したプロパティなので祖先に委ねないと壊れる、というのが本件の現象です。

### 対応

派生クラスで同名のプロパティを「かぶせる」のをやめ、別のプロパティ `rawHandlerSet: GameHandlerSet` を追加します。game-driver 側で参照する時はこちらだけ見るようにします。

ユニットテストを加えている他、akashic serve に組み込んで現象の不再現を確認しています。

別の方法としては「 `g.Game#handlerSet: g.GameHandlerSet` だけにして、game-driver 内から参照する時はダウンキャストする」があります。しかし逐一ダウンキャストが必要になる点をさておいても、ダウンキャストだと (その箇所だけでは) 成功する保証がないので、型的にクリーンではなくなります。

