### PR TITLE
fix: fix lost join/leave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.18.1
+* `JoinEvent`, `LeaveEvent` が受け取れない問題を修正
+
 ## 2.18.0
 * @akashic/akashic-engine@3.15.0 に追従
 * 旧ストレージ関連の実装を削除

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/src/TickGenerator.ts
+++ b/src/TickGenerator.ts
@@ -37,7 +37,11 @@ export class TickGenerator {
 		if (!this._generatingTick)
 			return;
 
-		const evs = this._eventBuffer.readEvents();
+		// NOTE: readEvents() と readJoinEventLeaves() は歴史的経緯により分離しているもので、現在は統合することもできる。
+		// ただし統合するとフレーム内のイベントの順序が変化する。この順序が問題になるケースは知られていないが、念のため分離したままにしている。
+		const normalEvents = this._eventBuffer.readEvents();
+		const joinLeaves = this._eventBuffer.readJoinLeaves();
+		const evs = (normalEvents && joinLeaves) ? normalEvents.concat(joinLeaves) : (normalEvents ?? joinLeaves);
 
 		this.tickTrigger.fire([
 			this._nextAge++,  // 0: フレーム番号


### PR DESCRIPTION
#203 で `readJoinLeaveEvents()` を呼び出す箇所ごと消えた結果、 join/leave 両イベントがロストしていました。これを修正します。

ユニットテストを加える他、手元のマルチプレイコンテンツがこの変更後動作することを akashic serve で目視確認しています。
