### PR TITLE
fix: accept changeState() without callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.19.1
+* `GameDriver#changeState()` のコールバック引数を省略できるように
+
 ## 2.19.0
 * @akashic/akashic-engine@3.16.0 に追従
 * @akashic/amflow@3.3.0 に追従

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/game-driver",
-      "version": "2.19.0",
+      "version": "2.19.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-engine": "~3.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.19.0",
+  "version": "2.19.1",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/src/GameDriver.ts
+++ b/src/GameDriver.ts
@@ -132,19 +132,22 @@ export class GameDriver {
 	 *
 	 * 引数 `param` のうち、省略されなかった値が新たに設定される。
 	 * `startGame()` によりゲームが開始されていた場合、暗黙に `stopGame()` が行われ、完了後 `startGame()` される。
+	 *
+	 * @param param 変更する内容
+	 * @param callback 完了時に呼び出されるコールバック。歴史的経緯により省略可能だが、通常省略せずコールバック呼び出しを待つ必要がある
 	 */
-	changeState(param: GameDriverInitializeParameterObject, callback: (err?: Error) => void): void {
+	changeState(param: GameDriverInitializeParameterObject, callback?: (err?: Error) => void): void {
 		const pausing = this._gameLoop && this._gameLoop.running;
 		if (pausing)
 			this._gameLoop?.stop();
 		this.initialize(param, err => {
 			if (err) {
-				callback(err);
+				callback?.(err);
 				return;
 			}
 			if (pausing)
 				this._gameLoop?.start();
-			callback();
+			callback?.();
 		});
 	}
 


### PR DESCRIPTION
掲題どおり。

通常必要ないパスですが、`changeState()` のコールバックが省略されるケースを受け付けます。

修正自明につきセルフマージします。
