### PR TITLE
fix: (DON'T MERGE) avoid targetTime overflow after 2024-06-11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - hotfix-2.7.1-overflow
 
 env:
   NODE_VERSION: 16

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.7.0",
+  "version": "2.7.0-hotfix.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/game-driver",
-      "version": "2.7.0",
+      "version": "2.7.0-hotfix.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-engine": "~3.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "url": "https://github.com/akashic-games/game-driver.git"
   },
   "publishConfig": {
+    "tag": "beta",
     "@akashic:registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.7.0",
+  "version": "2.7.0-hotfix.0",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -507,8 +507,10 @@ export class GameLoop {
 						//  時間ベースリプレイでは目標時刻 "以後" には進めないという制約がある。これを単純な実装で守るべく切り上げを断念している)
 						if (targetTime <= nextTickTime) {
 							// 次ティック時刻まで進めると目標時刻を超えてしまう: 目標時刻直前まで動いて抜ける(目標時刻直前までは来ないと目標時刻到達通知が永久にできない)
-							this._omittedTickDuration += targetTime - this._currentTime;
-							this._currentTime = Math.floor(targetTime / this._frameTime) * this._frameTime;
+							const gap = targetTime - this._currentTime;
+							this._omittedTickDuration += gap;
+							// targetTime を直接丸めると誤差が出る場合があるので、代わりに gap だけを丸めて加算する
+							this._currentTime += Math.floor(gap / this._frameTime) * this._frameTime;
 							break;
 						}
 						nextFrameTime = nextTickTime;


### PR DESCRIPTION
**マージしないでください** 。記録のための PR です。

2024-06-11 以降、 `Date.now()` の数値が大きくなりすぎて計算に浮動小数点誤差が生じる場合が出ました。特定のコンテンツで利用されている game-driver@2.7.1 に、これを回避する修正を加えます。 #177 以降は別の修正により再現しません。
