### PR TITLE
feat: support suspending and resuming the clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## unreleased changes
+## 2.26.0
 * @akashic/akashic-engine@3.21.0 に追従
 
 ## 2.25.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## unreleased changes
+* @akashic/akashic-engine@3.21.0 に追従
+
 ## 2.25.1
 * 内部モジュールの更新
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.25.1",
       "license": "MIT",
       "dependencies": {
-        "@akashic/akashic-engine": "~3.20.0",
+        "@akashic/akashic-engine": "~3.21.0",
         "@akashic/amflow-util": "~1.4.0",
         "@akashic/game-configuration": "~2.5.0"
       },
@@ -32,9 +32,10 @@
       }
     },
     "node_modules/@akashic/akashic-engine": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.20.0.tgz",
-      "integrity": "sha512-EmFJ3ieDz6vCceD0PKv6gRZW7iwzdZKjLb0p4MHXdXrWMPU7wG8VvXJEBuWqcRtNhogE4xCd7DVQh/ORrPMi0A==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/@akashic/akashic-engine/-/akashic-engine-3.21.0.tgz",
+      "integrity": "sha512-F1blWqBawo5k5sg+BxsDzPFfr6OP0FMzeyKZC0KaRFAAIubGaoQV3bbHgYiYeZS6LNzcIzUWn55WB0694y+pWQ==",
+      "license": "MIT",
       "dependencies": {
         "@akashic/game-configuration": "~2.5.0",
         "@akashic/pdi-types": "^1.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.25.1",
+  "version": "2.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/game-driver",
-      "version": "2.25.1",
+      "version": "2.26.0",
       "license": "MIT",
       "dependencies": {
         "@akashic/akashic-engine": "~3.21.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/game-driver",
-  "version": "2.25.1",
+  "version": "2.26.0",
   "description": "The driver module for the games using Akashic Engine",
   "main": "index.js",
   "typings": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@akashic/akashic-engine": "~3.20.0",
+    "@akashic/akashic-engine": "~3.21.0",
     "@akashic/amflow-util": "~1.4.0",
     "@akashic/game-configuration": "~2.5.0"
   }

--- a/src/EventBuffer.ts
+++ b/src/EventBuffer.ts
@@ -61,6 +61,11 @@ export interface EventFilterEntry {
  * 詳細は `setMode()` のコメントを参照。
  */
 export class EventBuffer implements pdi.PlatformEventHandler {
+	/**
+	 * ローカルイベントを受信した時にfireされる `g.Trigger` 。
+	 */
+	onLocalEventReceive: g.Trigger<pl.Event> = new g.Trigger();
+
 	_amflow: AMFlow;
 	_isLocalReceiver: boolean;
 	_isReceiver: boolean;
@@ -202,6 +207,7 @@ export class EventBuffer implements pdi.PlatformEventHandler {
 				!(this._skipping && this._discardsLocalEventsDuringSkip)
 			) {
 				this._unfilteredLocalEvents.push(pev);
+				this.onLocalEventReceive.fire(pev);
 			}
 			return;
 		}
@@ -226,6 +232,7 @@ export class EventBuffer implements pdi.PlatformEventHandler {
 
 	/**
 	 * filterを無視してイベントを追加する。
+	 * (本メソッド経由の場合 `onLocalEventReceive` の発火は不定であることに注意)
 	 */
 	addEventDirect(pev: pl.Event): void {
 		if (EventBuffer.isEventLocal(pev)) {

--- a/src/GameHandlerSet.ts
+++ b/src/GameHandlerSet.ts
@@ -16,6 +16,7 @@ export class GameHandlerSet implements g.GameHandlerSet {
 	raiseTickTrigger: g.Trigger<pl.Event[] | undefined> = new g.Trigger();
 	snapshotTrigger: g.Trigger<amf.StartPoint> = new g.Trigger();
 	changeSceneModeTrigger: g.Trigger<g.SceneMode> = new g.Trigger();
+	changeLocalTickSuspendedTrigger: g.Trigger<boolean> = new g.Trigger();
 	isSnapshotSaver: boolean;
 	_getCurrentTimeFunc: (() => number) | null = null;
 	_eventFilterFuncs: GameEventFilterFuncs | null = null;
@@ -83,6 +84,14 @@ export class GameHandlerSet implements g.GameHandlerSet {
 	getInstanceType(): "active" | "passive" {
 		// NOTE: Active かどうかは `shouldSaveSnapshot()` と等価なので、簡易対応としてこの実装を用いる。
 		return this.shouldSaveSnapshot() ? "active" : "passive";
+	}
+
+	suspendLocalTick(): void {
+		this.changeLocalTickSuspendedTrigger.fire(true);
+	}
+
+	resumeLocalTick(): void {
+		this.changeLocalTickSuspendedTrigger.fire(false);
 	}
 
 	saveSnapshot(

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -293,6 +293,7 @@ export class GameLoop {
 	setExecutionMode(execMode: ExecutionMode): void {
 		this._executionMode = execMode;
 		this._tickController.setExecutionMode(execMode);
+		// resume() が必要でないケースもありうるが、条件が煩雑で影響も軽微なので無条件で suspend を解除する
 		this.resume();
 	}
 
@@ -362,6 +363,7 @@ export class GameLoop {
 			this._clock.setDeltaTimeBrokenThreshold(conf.deltaTimeBrokenThreshold);
 		}
 
+		// resume() が必要でないケースもありうるが、条件が煩雑で影響も軽微なので無条件で suspend を解除する
 		this.resume();
 
 		// 以下は本来はプロパティごとに条件付き（e.g. deltaTimeBrokenThreshold のみが変更された場合など）でリセットすべきであるが、対象が多く条件分岐が煩雑になるため無条件にリセットしている。
@@ -453,6 +455,9 @@ export class GameLoop {
 	}
 
 	_handleLocalTickSuspended(suspended: boolean): void {
+		// 以下に該当する場合は clock を suspend しない。
+		//  - Active: tick が生成できなくなるため
+		//  - Replay: targetTimeFunc() の呼び出しをポーリングできなくなるため
 		if (this._executionMode === ExecutionMode.Active || this._loopMode !== LoopMode.Realtime)
 			return;
 

--- a/src/GameLoop.ts
+++ b/src/GameLoop.ts
@@ -233,10 +233,12 @@ export class GameLoop {
 		this._game.rawHandlerSet.raiseEventTrigger.add(this._onGameRaiseEvent, this);
 		this._game.rawHandlerSet.raiseTickTrigger.add(this._onGameRaiseTick, this);
 		this._game.rawHandlerSet.changeSceneModeTrigger.add(this._handleSceneChange, this);
+		this._game.rawHandlerSet.changeLocalTickSuspendedTrigger.add(this._handleLocalTickSuspended, this);
 		this._game._onStart.add(this._onGameStarted, this);
 		this._tickBuffer.gotNextTickTrigger.add(this._onGotNextFrameTick, this);
 		this._tickBuffer.gotNoTickTrigger.add(this._onGotNoTick, this);
 		this._tickBuffer.start();
+		this._eventBuffer.onLocalEventReceive.add(this._onReceiveLocalEvent, this);
 		this._updateGameAudioSuppression();
 	}
 
@@ -272,6 +274,14 @@ export class GameLoop {
 		this.running = false;
 	}
 
+	suspend(): void {
+		this._clock.suspend();
+	}
+
+	resume(): void {
+		this._clock.resume();
+	}
+
 	setNextAge(age: number): void {
 		this._tickController.setNextAge(age);
 	}
@@ -283,6 +293,7 @@ export class GameLoop {
 	setExecutionMode(execMode: ExecutionMode): void {
 		this._executionMode = execMode;
 		this._tickController.setExecutionMode(execMode);
+		this.resume();
 	}
 
 	getLoopConfiguration(): LoopConfiguration {
@@ -350,6 +361,8 @@ export class GameLoop {
 		if (conf.deltaTimeBrokenThreshold != null) {
 			this._clock.setDeltaTimeBrokenThreshold(conf.deltaTimeBrokenThreshold);
 		}
+
+		this.resume();
 
 		// 以下は本来はプロパティごとに条件付き（e.g. deltaTimeBrokenThreshold のみが変更された場合など）でリセットすべきであるが、対象が多く条件分岐が煩雑になるため無条件にリセットしている。
 		// 本メソッドは滅多に呼ばれず、次の 1 フレームの補間ティックが少なくなる程度のため影響も軽微である。
@@ -436,6 +449,18 @@ export class GameLoop {
 					this.errorTrigger.fire(new Error("Unknown LocalTickMode: " + localMode));
 					return;
 			}
+		}
+	}
+
+	_handleLocalTickSuspended(suspended: boolean): void {
+		if (this._executionMode === ExecutionMode.Active || this._loopMode !== LoopMode.Realtime)
+			return;
+
+		if (suspended) {
+			if (!this._tickBuffer.hasNextTick())
+				this.suspend();
+		} else {
+			this.resume();
 		}
 	}
 
@@ -580,11 +605,13 @@ export class GameLoop {
 					if (targetTime <= nextTickTime) {
 						// 次ティック時刻まで進めると目標時刻を超えてしまう: 目標時刻直前まで動いて抜ける(目標時刻直前までは来ないと目標時刻到達通知が永久にできない)
 						this._omittedTickDuration += targetTime - this._currentTickTime;
+						this._localAdvanceTime += targetTime - this._currentTickTime;
 						this._currentTime = Math.floor(targetTime / this._frameTime) * this._frameTime;
 						break;
 					}
 					nextFrameTime = nextTickTime;
 					this._omittedTickDuration += nextTickTime - this._currentTickTime;
+					this._localAdvanceTime += nextTickTime - this._currentTickTime;
 				} else {
 					if (this._sceneLocalMode === "interpolate-local") {
 						this._doLocalTick();
@@ -752,6 +779,7 @@ export class GameLoop {
 					// リプレイモードに切り替えた時に矛盾しないよう時刻を補正する(当該ティック時刻まで待った扱いにする)。
 					nextFrameTime = Math.ceil(explicitNextTickTime / this._frameTime) * this._frameTime;
 					this._omittedTickDuration += nextFrameTime - this._currentTickTime;
+					this._localAdvanceTime += nextFrameTime - this._currentTickTime;
 				} else {
 					if (this._sceneLocalMode === "interpolate-local") {
 						this._doLocalTick();
@@ -763,7 +791,6 @@ export class GameLoop {
 
 			this._currentTime = nextFrameTime;
 			this._currentTickTime = explicitNextTickTime ?? (this._currentTickTime + this._frameTime);
-			this._localAdvanceTime = 0;
 			const tick = this._tickBuffer.consume();
 			let consumedAge = -1;
 			this._events.length = 0;
@@ -785,6 +812,7 @@ export class GameLoop {
 					sceneChanged = game.tick(true, Math.floor(this._omittedTickDuration / this._frameTime), this._events);
 				}
 				this._omittedTickDuration = 0;
+				this._localAdvanceTime = 0;
 			} else {
 				// 時間は経過しているが消費すべきティックが届いていない
 				this._tickBuffer.requestTicks();
@@ -812,6 +840,9 @@ export class GameLoop {
 	}
 
 	_onGotNextFrameTick(): void {
+		// Tickを受信したら問答無用でクロックを開始する。
+		this.resume();
+
 		if (!this._waitingNextTick)
 			return;
 		if (this._loopMode === LoopMode.FrameByFrame) {
@@ -874,6 +905,10 @@ export class GameLoop {
 
 	_onEventsProcessed(): void {
 		this._eventBuffer.processEvents(this._sceneLocalMode === "full-local");
+	}
+
+	_onReceiveLocalEvent(_pev: pl.Event): void {
+		this.resume();
 	}
 
 	_setLoopRenderMode(mode: LoopRenderMode): void {

--- a/src/__tests__/Clock.spec.ts
+++ b/src/__tests__/Clock.spec.ts
@@ -300,4 +300,61 @@ describe("Clock", function() {
 
 		clock.stop();
 	});
+
+	function createMockClockAndLooper() {
+		const pf = new mockpf.Platform({});
+		const fps = 50;
+		const clock = new Clock({
+			fps: fps,
+			platform: pf,
+			maxFramePerOnce: 8,
+		});
+		const looper = clock._looper as mockpf.Looper;
+		looper.start = jest.fn();
+		looper.stop = jest.fn();
+		return { clock, looper };
+	}
+
+	it("should call Looper#start() once when start() is called", () => {
+		const { clock, looper } = createMockClockAndLooper();
+		clock.start();
+		expect(looper.start).toHaveBeenCalledTimes(1);
+	});
+
+	it("should not call Looper#start() again if already running", () => {
+		const { clock, looper } = createMockClockAndLooper();
+		clock.start();
+		clock.start();
+		expect(looper.start).toHaveBeenCalledTimes(1);
+	});
+
+	it("should call Looper#stop() once when stop() is called after start()", () => {
+		const { clock, looper } = createMockClockAndLooper();
+		clock.start();
+		clock.stop();
+		expect(looper.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("should call Looper#stop() once when suspend() is called while running", () => {
+		const { clock, looper } = createMockClockAndLooper();
+		clock.start();
+		clock.suspend();
+		expect(looper.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("should call Looper#start() again when resume() is called after suspend()", () => {
+		const { clock, looper } = createMockClockAndLooper();
+		clock.start();
+		clock.suspend();
+		clock.resume();
+		expect(looper.start).toHaveBeenCalledTimes(2);
+		expect(looper.stop).toHaveBeenCalledTimes(1);
+	});
+
+	it("should not call Looper#start() when resume() is called while not running", () => {
+		const { clock, looper } = createMockClockAndLooper();
+		clock.suspend();
+		clock.resume();
+		expect(looper.start).not.toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
# このPullRequestが解決する内容

https://github.com/akashic-games/akashic-engine/pull/524 の game-driver 側対応です。

- `GameHandlerSet#suspendLocalTick()`, `resumeLocalTick()` を実装
  - コンテンツ側からの任意のタイミングでクロックを再開/停止
  - Passive Realtime のインスタンスのみ対応
- `Clock#suspend()`, `Clock#resume()` を追加
- `GameLoop#suspend()`, `GameLoop#resume()` を追加
- `EventBuffer#onLocalEventReceive` を追加
- `GameLoop#_localAdvanceTime` の更新タイミングを一部修正

クロックの停止時、次のいずれかの契機によりクロックを再開します。
  1. tick の受信時
  2. local event の受信時
  3. `GameLoop#setLoopConfiguration()`, `GameLoop#setExecutionMode()`
    - Realtime -> Replay または Passive -> Active 切替時など

# TODO
- [x] `@akashic/akashic-engine` 更新追従
- [x] CHANGELOG.md 更新