### PR TITLE
chore: update package.json devEngines and .npmrc min-release-age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -51,5 +51,12 @@
   "dependencies": {
     "@akashic/akashic-engine": "~1.14.0",
     "es6-promise": "^4.2.8"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR updates both `package.json` (devEngines.packageManager) and `.npmrc` (min-release-age=7).